### PR TITLE
Fix `xt-connectors` summary

### DIFF
--- a/packages/xt-connectors/ato.yaml
+++ b/packages/xt-connectors/ato.yaml
@@ -12,10 +12,9 @@ builds:
 package:
   identifier: atopile/xt-connectors
   repository: https://github.com/atopile/packages
-  version: "0.1.0"
+  version: "0.1.1"
   authors:
     - name: atopile
       email: hi@atopile.io
-  summary: USB connectors for convenience
+  summary: XT power connectors
   license: MIT
-  homepage: https://github.com/atopile/packages


### PR DESCRIPTION
This pull request updates the metadata for the `atopile/xt-connectors` package in the `ato.yaml` file. The changes include updating the version, summary, and removing the homepage field.

Key changes to the `ato.yaml` file:

* Updated the `version` from `"0.1.0"` to `"0.1.1"`.
* Changed the `summary` from "USB connectors for convenience" to "XT power connectors".
* Removed the `homepage` field entirely.