### PR TITLE
Add missing connection of output to button pin

### DIFF
--- a/packages/buttons/buttons.ato
+++ b/packages/buttons/buttons.ato
@@ -67,6 +67,8 @@ module ButtonPullup:
     pullup.resistance = 10kohms +/- 20%
     pullup.package = "R0402"
 
+    output.line ~ btn.in
+
     output.reference.hv ~ pullup.p1; pullup.p2 ~ btn.in; btn.out ~ output.reference.gnd
 
 
@@ -76,6 +78,8 @@ module ButtonPulldown:
     pulldown = new Resistor
     pulldown.resistance = 10kohms +/- 20%
     pulldown.package = "R0402"
+
+    output.line ~ btn.in
 
     output.reference.gnd ~ pulldown.p1; pulldown.p2 ~ btn.in; btn.out ~ output.reference.hv
 


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/83b84e4c-c1d1-4d2d-a753-e066d4e0743c)

After:
![image](https://github.com/user-attachments/assets/554d9f4a-8c9b-4eea-87d3-703918c2ec7e)

Application code:
```python
reset_switch.output.reference ~ power_3v3
reset_switch.output.line ~ enable.line
reset_switch.btn -> ButtonSKRPACE010
reset_rc_capacitor.power.hv ~ reset_switch.output.line
reset_rc_capacitor.power.lv ~ reset_switch.output.reference.lv
```