### PR TITLE
Test artifacts publish

### DIFF
--- a/packages/addressable-leds/ato.yaml
+++ b/packages/addressable-leds/ato.yaml
@@ -12,7 +12,7 @@ builds:
 package:
   identifier: atopile/addressable-leds
   repository: https://github.com/atopile/packages
-  version: "0.1.0"
+  version: "0.1.1"
   authors:
     - name: atopile
       email: hi@atopile.io


### PR DESCRIPTION
This pull request includes a version bump for the `addressable-leds` package in its metadata file.

* [`packages/addressable-leds/ato.yaml`](diffhunk://#diff-75e76d5b6134e763f57794665352c3d0d0c5d809fd98741544d562a71f9c345aL15-R15): Updated the package version from `0.1.0` to `0.1.1` to reflect a new release.