### PR TITLE
Fix Markdown code block language markers

### DIFF
--- a/packages/rpi-cm5/README.md
+++ b/packages/rpi-cm5/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-```python
+```ato
 from "atopile/cm5.ato" import CM5
 
 module App:

--- a/packages/saleae-header/README.md
+++ b/packages/saleae-header/README.md
@@ -6,7 +6,7 @@ Header configured for use with Saleae debug probes, includes interfaces for sign
 
 ## Usage Example
 
-```
+```ato
 import saleae-header from "saleae-header/saleae-header.ato"
 import Power from "generics/interfaces.ato"
 

--- a/packages/ti-tps54560x/README.md
+++ b/packages/ti-tps54560x/README.md
@@ -41,7 +41,7 @@ This package provides:
 
 To use this package in your design:
 
-```python
+```ato
 from "atopile/ti-tps54560x/ti-tps54560x.ato" import TPS54560x
 
 // Example usage in your design


### PR DESCRIPTION
Syntax highlighting for `ato` code is now available