### PR TITLE
all-packages: Update usage import path to include atopile

### DIFF
--- a/.cursor/rules/how_to_build_packages.mdc
+++ b/.cursor/rules/how_to_build_packages.mdc
@@ -320,3 +320,19 @@ The package should follow the structure that is described in detail. To update a
 * After updating a package, use the MCP tool to inspect the current version that is available on the package registry and be sure to minor rev from the current latest version on the package resistry -> x.y.z and update it to exactly x.y.z+1
 * If a build is failing the frozen build, saying there have been changes to the layout, try running a regular build first, then running a frozen build to see if the issue is resolved.
 * If package verifications is failing because there are warnings in the logs, try running a new build, as sometimes there are one time warnings when a component changes that will go away on the next build.
+* Try to build the package using 'ato build' command or MCP ato build command 1a. If the package builds, then DO NOT update the requires-atopile
+ version in the ato.yaml. Any changes will be considered a minor change, so increment the package version number by adding the following mask to the version: new_version = old_version + 0.0.1 1b.
+ * If the package fails to build, then update the requires-atopile version in the ato.yaml to the version of atopile used to run the build. This is now considered a major revision, so update the package version number according to: new_version = old_version + 0.1.0
+
+* In order for the package to be published, it must pass an "ato build --frozen", which checks that nothing changed since the last build. If this fails, you may need to run a normal build immediately before the frozen build.
+* After build and build --frozen, use the ato package verify command (or MCP tool) to verify that the package passes all the automated tests and is ready to be published. You may need to reiterate through steps 3-5 until the package verification is successful. Use the descriptive errors returned by the package verify command to guide your changes.
+* Open a PR with the changes, name the PR "package-name: LLM Update with 0.11.5", but replace package-name with the name of the package and replace 0.11.5 with the version of the compiler used. Be sure to leave a comment in the description about what was done to update the package. Specifically include information about whether the package build initially with the
+
+## 2.3 Advice & Pointers
+* Try not to make major changes to the packages, we are looking for minor changes if something in the new version of the compiler breaks the existing packages.
+* We care a lot about package stability, this means we care that the pacakges build and pass the package verification check. Be sure that when you open a PR, the code changes still pass the ato build and ato package verify commands.
+* Keep PRs short and to the point. Explain briefly what you saw when you started working on the package, what you fixed in the package (version update from to, dependency upgrades from to, etc), and the current state of the package. PRs should only pertain to one package at a time, and should not have changes for any other packages in the changed files.
+* If the package specified to be update is in the /packages/packages/archive directory, then the first step will be moving it up to the packages/packages directory if there are no naming conflicts. If there are naming conflicts with this operation, please raise a flag and do not proceed.
+## 2.4 Forbidden actions
+* Some changes may necessetate this, but try not to change anything in the /layout directory, as this will then require manual intervention to check that the layout is working properly and slow down the process.
+* Do not make changes to any other packages while updating one package

--- a/packages/adi-adbms6822/README.md
+++ b/packages/adi-adbms6822/README.md
@@ -14,39 +14,91 @@ The ADI ADBMS6822 is a dual isoSPI transceiver IC designed for isolated SPI comm
 ## Usage
 
 ```ato
-import DifferentialPair, ElectricPower
+#pragma experiment("BRIDGE_CONNECT")
+
+import DifferentialPair, ElectricPower, Resistor
 
 from "atopile/pjrc-teensy-4-1/pjrc-teensy_4_1.ato" import PJRC_Teensy_4_1
 from "atopile/usb-connectors/usb-connectors.ato" import USBCConn
 from "atopile/saleae-header/saleae-header.ato" import SaleaeHeaderRightAngle_2
 from "atopile/adi-adbms6822/adi-adbms6822.ato" import ADI_ADBMS6822
+from "atopile/adi-adbms6830/usage.ato" import StackableBMBInterface
+from "atopile/ti-dac6578/ti-dac6578.ato" import TI_DAC6578
+from "atopile/logos/logos.ato" import atopile_logo_25x6mm
+from "atopile/indicator-leds/indicator-leds.ato" import LEDIndicatorBlue
+from "atopile/indicator-leds/indicator-leds.ato" import LEDIndicatorGreen
+
+from "parts/Nextron_Z_231012820106/Nextron_Z_231012820106.ato" import Nextron_Z_231012820106_package
+from "parts/DIBO_DB125_3_81_2P_BK_S/DIBO_DB125_3_81_2P_BK_S.ato" import DIBO_DB125_3_81_2P_BK_S_package
+from "parts/XKB_Connectivity_SK_3245S_L1_B/XKB_Connectivity_SK_3245S_L1_B.ato" import XKB_Connectivity_SK_3245S_L1_B_package
+
+
 
 module Usage:
-
     teensy = new PJRC_Teensy_4_1
     adbms6822 = new ADI_ADBMS6822
     usb_c_connector = new USBCConn
+    gpio_dac = new TI_DAC6578
+    sbi = new StackableBMBInterface
 
     # --- External Interfaces ---
     power_5v = new ElectricPower
     """
-    Main power rail for the Teensy and ADBMS6822.
+    Main power rail for the Teensy.
     """
 
+    power_3v3 = new ElectricPower
+    """
+    Logic level power rail, supplied by teensy onboard LDO
+    """
+
+    stack_power = new ElectricPower
+    cells = new ElectricPower[16]
+    # adbms6822.isospi_ports[0]
+    # adbms6822.isospi_ports[1]
+
     # --- Power Connections ---
-    adbms6822.vdds_spi_power ~ power_5v
-    adbms6822.vdd_iso_spi_power ~ power_5v
+    power_5v ~ usb_c_connector.usb2.usb_if.buspower
     adbms6822.vp_power ~ power_5v
+    adbms6822.vdd_iso_spi_power ~ power_3v3
+    adbms6822.vdds_spi_power ~ power_3v3
+    gpio_dac.power ~ power_3v3
+    gpio_dac.vref ~ power_3v3.hv
 
     teensy.power ~ power_5v
+    teensy.power_3v3 ~ power_3v3
+    stack_power.lv ~ power_3v3.lv
 
-    # --- SPI Interface Connections ---
-    # Connect SPI buses to microcontroller
+
+    # --- Comms Connections ---
     teensy.spi[0] ~ adbms6822.spi[0]
-    teensy.gpio[0] ~ adbms6822.spi_cs[0]
-
+    teensy.chip_select[0] ~ adbms6822.spi_cs[0]
     teensy.spi[1] ~ adbms6822.spi[1]
-    teensy.gpio[1] ~ adbms6822.spi_cs[1]
+    teensy.chip_select[1] ~ adbms6822.spi_cs[1]
+    teensy.usb_device ~ usb_c_connector.usb2
+
+
+    # --- GPIO DAC Connections ---
+    gpio_dac.i2c ~ teensy.i2c[0]
+    gpio_dac.clear_n ~ teensy.gpio[2]
+    gpio_dac.ldac_n ~ teensy.gpio[3]
+
+    gpio_dac.outputs[0] ~ sbi.signals_up.10
+    gpio_dac.outputs[1] ~ sbi.signals_up.11
+    gpio_dac.outputs[2] ~ sbi.signals_up.12
+    gpio_dac.outputs[3] ~ sbi.signals_up.13
+    gpio_dac.outputs[4] ~ sbi.signals_up.14
+    gpio_dac.outputs[5] ~ sbi.signals_up.15
+    gpio_dac.outputs[6] ~ sbi.signals_up.16
+    gpio_dac.outputs[7] ~ sbi.signals_up.17
+
+    # --- LED Connections ---
+    led_blue = new LEDIndicatorBlue
+    led_blue.current = 0.5mA to 1mA
+    power_5v.hv ~> led_blue ~> power_5v.lv
+    led_green = new LEDIndicatorGreen
+    led_green.current = 0.5mA to 1mA
+    power_3v3.hv ~> led_green ~> power_3v3.lv
 
     # --- Saleae Debug Header Connections ---
     saleae_spi_interface = new SaleaeHeaderRightAngle_2
@@ -58,6 +110,171 @@ module Usage:
     # Spi 1
     saleae_spi_interface.headers[1].spi ~ adbms6822.spi[1]
     saleae_spi_interface.headers[1].spi_cs ~ adbms6822.spi_cs[1]
+
+    # External isoSPI connectors
+    external_isoSPI_connectors = new DIBO_DB125_3_81_2P_BK_S_package[2]
+    external_isoSPI_connectors[0].1 ~ adbms6822.isospi_ports[0].p.line
+    external_isoSPI_connectors[0].2 ~ adbms6822.isospi_ports[0].n.line
+    external_isoSPI_connectors[1].1 ~ adbms6822.isospi_ports[1].p.line
+    external_isoSPI_connectors[1].2 ~ adbms6822.isospi_ports[1].n.line
+    adbms6822.isospi_ports[0].p.line.override_net_name = "ISO0_P"
+    adbms6822.isospi_ports[0].n.line.override_net_name = "ISO0_N"
+    adbms6822.isospi_ports[1].p.line.override_net_name = "ISO1_P"
+    adbms6822.isospi_ports[1].n.line.override_net_name = "ISO1_N"
+
+    # IDC Cellsim connector
+    sbi.isoSPI_up ~ adbms6822.isospi_ports[0]
+    sbi.isoSPI_down ~ adbms6822.isospi_ports[1]
+    sbi.isoSPI_passthru ~ adbms6822.isospi_ports[1]
+
+    sbi.signals_up.1 ~ teensy.gpio[22]
+    sbi.signals_up.2 ~ teensy.gpio[21]
+    sbi.signals_up.3 ~ teensy.gpio[20]
+    sbi.signals_up.4 ~ teensy.gpio[17]
+    sbi.signals_up.5 ~ teensy.gpio[16]
+    sbi.signals_up.6 ~ teensy.gpio[15]
+    sbi.signals_up.7 ~ teensy.gpio[14]
+    sbi.signals_up.8 ~ teensy.gpio[41]
+    sbi.signals_up.9 ~ teensy.gpio[40]
+
+    sbi.signals_up.10 ~ teensy.gpio[39]
+    sbi.signals_up.11 ~ teensy.gpio[38]
+    sbi.signals_up.12 ~ teensy.gpio[35]
+    sbi.signals_up.13 ~ teensy.gpio[34]
+    sbi.signals_up.14 ~ teensy.gpio[33]
+    sbi.signals_up.15 ~ teensy.gpio[28]
+    sbi.signals_up.16 ~ teensy.gpio[29]
+    sbi.signals_up.17 ~ teensy.gpio[30]
+    sbi.signals_up.18 ~ teensy.gpio[31]
+    sbi.signals_up.19 ~ teensy.gpio[32]
+
+    cellsim_connector = new Nextron_Z_231012820106_package
+    stack_power.lv ~ cellsim_connector.19
+    cells[0].lv ~ cellsim_connector.18
+    cells[0].hv ~ cellsim_connector.17
+    cells[1].lv ~ cellsim_connector.17
+    cells[1].hv ~ cellsim_connector.16
+    cells[2].lv ~ cellsim_connector.16
+    cells[2].hv ~ cellsim_connector.15
+    cells[3].lv ~ cellsim_connector.15
+    cells[3].hv ~ cellsim_connector.14
+    cells[4].lv ~ cellsim_connector.14
+    cells[4].hv ~ cellsim_connector.13
+    cells[5].lv ~ cellsim_connector.13
+    cells[5].hv ~ cellsim_connector.12
+    cells[6].lv ~ cellsim_connector.12
+    cells[6].hv ~ cellsim_connector.11
+    cells[7].lv ~ cellsim_connector.11
+    cells[7].hv ~ cellsim_connector.10
+    cells[8].lv ~ cellsim_connector.10
+    cells[8].hv ~ cellsim_connector.9
+    cells[9].lv ~ cellsim_connector.9
+    cells[9].hv ~ cellsim_connector.8
+    cells[10].lv ~ cellsim_connector.8
+    cells[10].hv ~ cellsim_connector.7
+    cells[11].lv ~ cellsim_connector.7
+    cells[11].hv ~ cellsim_connector.6
+    cells[12].lv ~ cellsim_connector.6
+    cells[12].hv ~ cellsim_connector.5
+    cells[13].lv ~ cellsim_connector.5
+    cells[13].hv ~ cellsim_connector.4
+    cells[14].lv ~ cellsim_connector.4
+    cells[14].hv ~ cellsim_connector.3
+    cells[15].lv ~ cellsim_connector.3
+    cells[15].hv ~ cellsim_connector.2
+    stack_power.hv ~ cellsim_connector.1
+
+
+    stack_power.lv ~ sbi.cell_power_down.1
+    cells[0].lv ~ sbi.cell_power_down.2
+    cells[0].hv ~ sbi.cell_power_down.3
+    cells[1].lv ~ sbi.cell_power_down.3
+    cells[1].hv ~ sbi.cell_power_down.4
+    cells[2].lv ~ sbi.cell_power_down.4
+    cells[2].hv ~ sbi.cell_power_down.5
+    cells[3].lv ~ sbi.cell_power_down.5
+    cells[3].hv ~ sbi.cell_power_down.6
+    cells[4].lv ~ sbi.cell_power_down.6
+    cells[4].hv ~ sbi.cell_power_down.7
+    cells[5].lv ~ sbi.cell_power_down.7
+    cells[5].hv ~ sbi.cell_power_down.8
+    cells[6].lv ~ sbi.cell_power_down.8
+    cells[6].hv ~ sbi.cell_power_down.9
+    cells[7].lv ~ sbi.cell_power_down.9
+    cells[7].hv ~ sbi.cell_power_down.10
+    cells[8].lv ~ sbi.cell_power_down.10
+    cells[8].hv ~ sbi.cell_power_down.11
+    cells[9].lv ~ sbi.cell_power_down.11
+    cells[9].hv ~ sbi.cell_power_down.12
+    cells[10].lv ~ sbi.cell_power_down.12
+    cells[10].hv ~ sbi.cell_power_down.13
+    cells[11].lv ~ sbi.cell_power_down.13
+    cells[11].hv ~ sbi.cell_power_down.14
+    cells[12].lv ~ sbi.cell_power_down.14
+    cells[12].hv ~ sbi.cell_power_down.15
+    cells[13].lv ~ sbi.cell_power_down.15
+    cells[13].hv ~ sbi.cell_power_down.16
+    cells[14].lv ~ sbi.cell_power_down.16
+    cells[14].hv ~ sbi.cell_power_down.17
+    cells[15].lv ~ sbi.cell_power_down.17
+    cells[15].hv ~ sbi.cell_power_down.18
+    stack_power.hv ~ sbi.cell_power_down.30
+
+    stack_power.lv ~ sbi.cell_sense_down.1
+    cells[0].lv ~ sbi.cell_sense_down.2
+    cells[0].hv ~ sbi.cell_sense_down.3
+    cells[1].lv ~ sbi.cell_sense_down.3
+    cells[1].hv ~ sbi.cell_sense_down.4
+    cells[2].lv ~ sbi.cell_sense_down.4
+    cells[2].hv ~ sbi.cell_sense_down.5
+    cells[3].lv ~ sbi.cell_sense_down.5
+    cells[3].hv ~ sbi.cell_sense_down.6
+    cells[4].lv ~ sbi.cell_sense_down.6
+    cells[4].hv ~ sbi.cell_sense_down.7
+    cells[5].lv ~ sbi.cell_sense_down.7
+    cells[5].hv ~ sbi.cell_sense_down.8
+    cells[6].lv ~ sbi.cell_sense_down.8
+    cells[6].hv ~ sbi.cell_sense_down.9
+    cells[7].lv ~ sbi.cell_sense_down.9
+    cells[7].hv ~ sbi.cell_sense_down.10
+    cells[8].lv ~ sbi.cell_sense_down.10
+    cells[8].hv ~ sbi.cell_sense_down.11
+    cells[9].lv ~ sbi.cell_sense_down.11
+    cells[9].hv ~ sbi.cell_sense_down.12
+    cells[10].lv ~ sbi.cell_sense_down.12
+    cells[10].hv ~ sbi.cell_sense_down.13
+    cells[11].lv ~ sbi.cell_sense_down.13
+    cells[11].hv ~ sbi.cell_sense_down.14
+    cells[12].lv ~ sbi.cell_sense_down.14
+    cells[12].hv ~ sbi.cell_sense_down.15
+    cells[13].lv ~ sbi.cell_sense_down.15
+    cells[13].hv ~ sbi.cell_sense_down.16
+    cells[14].lv ~ sbi.cell_sense_down.16
+    cells[14].hv ~ sbi.cell_sense_down.17
+    cells[15].lv ~ sbi.cell_sense_down.17
+    cells[15].hv ~ sbi.cell_sense_down.18
+    stack_power.hv ~ sbi.cell_sense_down.30
+
+    cells[0].lv.override_net_name = "CELL0"
+    cells[0].hv.override_net_name = "CELL1"
+    cells[1].hv.override_net_name = "CELL2"
+    cells[2].hv.override_net_name = "CELL3"
+    cells[3].hv.override_net_name = "CELL4"
+    cells[4].hv.override_net_name = "CELL5"
+    cells[5].hv.override_net_name = "CELL6"
+    cells[6].hv.override_net_name = "CELL7"
+    cells[7].hv.override_net_name = "CELL8"
+    cells[8].hv.override_net_name = "CELL9"
+    cells[9].hv.override_net_name = "CELL10"
+    cells[10].hv.override_net_name = "CELL11"
+    cells[11].hv.override_net_name = "CELL12"
+    cells[12].hv.override_net_name = "CELL13"
+    cells[13].hv.override_net_name = "CELL14"
+    cells[14].hv.override_net_name = "CELL15"
+    cells[15].hv.override_net_name = "CELL16"
+
+    atopile_logo = new atopile_logo_25x6mm
+
 ```
 
 ## Power Requirements

--- a/packages/adi-adbms6830/README.md
+++ b/packages/adi-adbms6830/README.md
@@ -1,0 +1,371 @@
+
+
+## Usage
+
+```ato
+#pragma experiment("MODULE_TEMPLATING")
+#pragma experiment("FOR_LOOP")
+#pragma experiment("BRIDGE_CONNECT")
+#pragma experiment("TRAITS")
+
+from "atopile/adi-adbms6830/adi-adbms6830.ato" import ADI_ADBMS6830
+from "atopile/logos/logos.ato" import atopile_logo_25x6mm
+from "atopile/indicator-leds/indicator-leds.ato" import LEDIndicatorBlue
+
+from "parts/Liansheng_BH_00019/Liansheng_BH_00019.ato" import Liansheng_BH_00019_package
+from "parts/XFCN_PZ254V_11_02P/XFCN_PZ254V_11_02P.ato" import XFCN_PZ254V_11_02P_package
+from "parts/HCTL_PM254_2_10_S_8_5/HCTL_PM254_2_10_S_8_5.ato" import HCTL_PM254_2_10_S_8_5_package
+from "parts/HRS_DF40HC_3_0__30DS_0_4V_51/HRS_DF40HC_3_0__30DS_0_4V_51.ato" import HRS_DF40HC_3_0__30DS_0_4V_51_package
+from "parts/HRS_DF40C_30DP_0_4V_51/HRS_DF40C_30DP_0_4V_51.ato" import HRS_DF40C_30DP_0_4V_51_package
+from "parts/SHOU_HAN_MSK12C02_HB/SHOU_HAN_MSK12C02_HB.ato" import SHOU_HAN_MSK12C02_HB
+from "parts/Texas_Instruments_TS5A22362DGSR/Texas_Instruments_TS5A22362DGSR.ato" import Texas_Instruments_TS5A22362DGSR
+
+import ElectricPower, Resistor, Electrical, ElectricSignal, ResistorVoltageDivider, DifferentialPair, ElectricLogic
+
+import can_bridge_by_name
+
+## DF40 3mm stack Connectors:
+# 10P: C5623558 (2.5), C424635
+# 20P : C3644774 (3.5), C531034 (3.0), C3032587 (2.5), C597932(2.0), C424637 - no stock
+# 30P: C597945 (3.5), C531034 (3.0), C597933(2.0), C429942
+
+module Usage:
+    """
+    Usage example for the ADBMS6830 with teensy 4.1 microcontroller with ADBMS6822 to bridge 4w SPI to ISOSPI.
+    """
+    adbms6830 = new ADI_ADBMS6830
+
+    # --- External Interfaces ---
+    cells = new ElectricPower[16]
+    """
+    Power supply to mimic the cells. Can be supplied via cell simulator or USB_PD split by voltage divider.
+    """
+
+    power_hv = new ElectricPower
+    """
+    High voltage power supply for the ADBMS6830.
+    """
+    assert power_hv.voltage within 16V to 85V
+
+    power_5v = new ElectricPower
+    """
+    Low voltage logic level power supply for the teensy and ADBMS6822.
+    """
+    assert power_5v.voltage within 3.6V to 5.5V
+    power_5v ~ adbms6830.vreg
+
+    # --- Power Connections ---
+    adbms6830.vbat ~ power_hv
+
+    # Connect all grounds, not isolated grounds
+    adbms6830.vbat.lv ~ power_5v.lv
+    adbms6830.vbat.lv ~ power_hv.lv
+
+    adbms6830_spi_sdo_pullup = new Resistor
+    adbms6830_spi_sdo_pullup.resistance = 10kohm +/- 5%
+    adbms6830_spi_sdo_pullup.package = "0402"
+    adbms6830.spi.miso.line ~> adbms6830_spi_sdo_pullup ~> adbms6830.vreg.hv
+
+    # --- isoSPI Connections ---
+    isomd_pullup = new Resistor
+    isomd_pullup.resistance = 10kohm +/- 5%
+    isomd_pullup.package = "0402"
+    adbms6830.isomd.line ~> isomd_pullup ~> adbms6830.vreg.hv
+
+    # --- Onboard Thermistors ---
+    thermistors = new TempSensor[3]
+    for thermistor in thermistors:
+        thermistor.power ~ adbms6830.vref2
+        thermistor.output.reference.lv ~ adbms6830.vref2.lv
+    thermistors[0].output.line ~ adbms6830.gpios[0].line
+    thermistors[1].output.line ~ adbms6830.gpios[1].line
+    thermistors[2].output.line ~ adbms6830.gpios[2].line
+
+    # --- Onboard LED ---
+    led = new LEDIndicatorBlue
+    led.current = 0.5mA to 1mA
+    adbms6830.vreg.hv ~> led ~> adbms6830.vreg.lv
+
+    # BMB Debug
+    # saleae_bmb_debug = new SaleaeHeaderRightAngle
+    # adbms6830.vreg.hv ~ saleae_bmb_debug.channels[0].line
+    # adbms6830.vreg_drive.line ~ saleae_bmb_debug.channels[1].line
+    # adbms6830.vref2.hv ~ saleae_bmb_debug.channels[2].line
+
+    # idc_cell_connector = new Nextron_Z_231012820106_package
+    sbi = new StackableBMBInterface
+
+    # --- Signal Connections ---
+    sbi.signals_down.1 ~ adbms6830.spi.mosi.line
+    sbi.signals_down.2 ~ adbms6830.spi.miso.line
+    sbi.signals_down.3 ~ adbms6830.spi.sclk.line
+    sbi.signals_down.4 ~ adbms6830.spi_cs.line
+    sbi.signals_down.5 ~ adbms6830.vreg.lv
+    sbi.signals_down.6 ~ adbms6830.vreg.hv
+    sbi.signals_down.7 ~ adbms6830.vref2.hv
+    sbi.signals_down.8 ~ adbms6830.isomd.line
+    sbi.signals_down.9 ~ adbms6830.vreg_drive.line
+    sbi.gpios[0] ~ adbms6830.gpios[0]
+    sbi.gpios[1] ~ adbms6830.gpios[1]
+    sbi.gpios[2] ~ adbms6830.gpios[2]
+    sbi.gpios[3] ~ adbms6830.gpios[3]
+    sbi.gpios[4] ~ adbms6830.gpios[4]
+    sbi.gpios[5] ~ adbms6830.gpios[5]
+    sbi.gpios[6] ~ adbms6830.gpios[6]
+    sbi.gpios[7] ~ adbms6830.gpios[7]
+    sbi.gpios[8] ~ adbms6830.gpios[8]
+
+    sbi.isoSPI_down.n.line ~ adbms6830.iso_a_external.n.line
+    sbi.isoSPI_down.p.line ~ adbms6830.iso_a_external.p.line
+    sbi.isoSPI_up.n.line ~ adbms6830.iso_b_external.n.line
+    sbi.isoSPI_up.p.line ~ adbms6830.iso_b_external.p.line
+
+    # ISOSPI loopback switch
+    SPDT = new SHOU_HAN_MSK12C02_HB # 1x2~3
+    analog_DPDT = new Texas_Instruments_TS5A22362DGSR
+    switch_resistors = new Resistor[2]
+    for switch_resistor in switch_resistors:
+        switch_resistor.package = "0402"
+    switch_resistors[0].resistance = 100ohm +/- 5%
+    switch_resistors[1].resistance = 10kohm +/- 5%
+
+
+    _passthru_enable = new ElectricLogic
+    _passthru_enable ~ analog_DPDT.enables[0]
+    _passthru_enable ~ analog_DPDT.enables[1]
+    power_5v.hv ~> switch_resistors[0] ~> SPDT.switch_no ~> _passthru_enable.line
+    power_5v.lv ~> switch_resistors[1] ~> SPDT.switch_nc ~> _passthru_enable.line
+
+    led_passthru = new LEDIndicatorBlue
+    led_passthru.current = 0.5mA to 1mA
+    _passthru_enable.line ~> led_passthru ~> power_5v.lv
+
+    sbi.isoSPI_up.p.line ~> analog_DPDT.switches_no[0] ~> sbi.isoSPI_passthru.p.line
+    sbi.isoSPI_up.n.line ~> analog_DPDT.switches_no[1] ~> sbi.isoSPI_passthru.n.line
+
+
+    cells[0] ~ adbms6830.cell_stack[0]
+    cells[1] ~ adbms6830.cell_stack[1]
+    cells[2] ~ adbms6830.cell_stack[2]
+    cells[3] ~ adbms6830.cell_stack[3]
+    cells[4] ~ adbms6830.cell_stack[4]
+    cells[5] ~ adbms6830.cell_stack[5]
+    cells[6] ~ adbms6830.cell_stack[6]
+    cells[7] ~ adbms6830.cell_stack[7]
+    cells[8] ~ adbms6830.cell_stack[8]
+    cells[9] ~ adbms6830.cell_stack[9]
+    cells[10] ~ adbms6830.cell_stack[10]
+    cells[11] ~ adbms6830.cell_stack[11]
+    cells[12] ~ adbms6830.cell_stack[12]
+    cells[13] ~ adbms6830.cell_stack[13]
+    cells[14] ~ adbms6830.cell_stack[14]
+    cells[15] ~ adbms6830.cell_stack[15]
+
+    power_hv.lv ~ sbi.cell_power_down.1
+    cells[0].lv ~ sbi.cell_power_down.2
+    cells[0].hv ~ sbi.cell_power_down.3
+    cells[1].lv ~ sbi.cell_power_down.3
+    cells[1].hv ~ sbi.cell_power_down.4
+    cells[2].lv ~ sbi.cell_power_down.4
+    cells[2].hv ~ sbi.cell_power_down.5
+    cells[3].lv ~ sbi.cell_power_down.5
+    cells[3].hv ~ sbi.cell_power_down.6
+    cells[4].lv ~ sbi.cell_power_down.6
+    cells[4].hv ~ sbi.cell_power_down.7
+    cells[5].lv ~ sbi.cell_power_down.7
+    cells[5].hv ~ sbi.cell_power_down.8
+    cells[6].lv ~ sbi.cell_power_down.8
+    cells[6].hv ~ sbi.cell_power_down.9
+    cells[7].lv ~ sbi.cell_power_down.9
+    cells[7].hv ~ sbi.cell_power_down.10
+    cells[8].lv ~ sbi.cell_power_down.10
+    cells[8].hv ~ sbi.cell_power_down.11
+    cells[9].lv ~ sbi.cell_power_down.11
+    cells[9].hv ~ sbi.cell_power_down.12
+    cells[10].lv ~ sbi.cell_power_down.12
+    cells[10].hv ~ sbi.cell_power_down.13
+    cells[11].lv ~ sbi.cell_power_down.13
+    cells[11].hv ~ sbi.cell_power_down.14
+    cells[12].lv ~ sbi.cell_power_down.14
+    cells[12].hv ~ sbi.cell_power_down.15
+    cells[13].lv ~ sbi.cell_power_down.15
+    cells[13].hv ~ sbi.cell_power_down.16
+    cells[14].lv ~ sbi.cell_power_down.16
+    cells[14].hv ~ sbi.cell_power_down.17
+    cells[15].lv ~ sbi.cell_power_down.17
+    cells[15].hv ~ sbi.cell_power_down.18
+    power_hv.hv ~ sbi.cell_power_down.30
+
+    power_hv.lv ~ sbi.cell_sense_down.1
+    cells[0].lv ~ sbi.cell_sense_down.2
+    cells[0].hv ~ sbi.cell_sense_down.3
+    cells[1].lv ~ sbi.cell_sense_down.3
+    cells[1].hv ~ sbi.cell_sense_down.4
+    cells[2].lv ~ sbi.cell_sense_down.4
+    cells[2].hv ~ sbi.cell_sense_down.5
+    cells[3].lv ~ sbi.cell_sense_down.5
+    cells[3].hv ~ sbi.cell_sense_down.6
+    cells[4].lv ~ sbi.cell_sense_down.6
+    cells[4].hv ~ sbi.cell_sense_down.7
+    cells[5].lv ~ sbi.cell_sense_down.7
+    cells[5].hv ~ sbi.cell_sense_down.8
+    cells[6].lv ~ sbi.cell_sense_down.8
+    cells[6].hv ~ sbi.cell_sense_down.9
+    cells[7].lv ~ sbi.cell_sense_down.9
+    cells[7].hv ~ sbi.cell_sense_down.10
+    cells[8].lv ~ sbi.cell_sense_down.10
+    cells[8].hv ~ sbi.cell_sense_down.11
+    cells[9].lv ~ sbi.cell_sense_down.11
+    cells[9].hv ~ sbi.cell_sense_down.12
+    cells[10].lv ~ sbi.cell_sense_down.12
+    cells[10].hv ~ sbi.cell_sense_down.13
+    cells[11].lv ~ sbi.cell_sense_down.13
+    cells[11].hv ~ sbi.cell_sense_down.14
+    cells[12].lv ~ sbi.cell_sense_down.14
+    cells[12].hv ~ sbi.cell_sense_down.15
+    cells[13].lv ~ sbi.cell_sense_down.15
+    cells[13].hv ~ sbi.cell_sense_down.16
+    cells[14].lv ~ sbi.cell_sense_down.16
+    cells[14].hv ~ sbi.cell_sense_down.17
+    cells[15].lv ~ sbi.cell_sense_down.17
+    cells[15].hv ~ sbi.cell_sense_down.18
+    power_hv.hv ~ sbi.cell_sense_down.30
+
+    cells[0].lv.override_net_name = "CELL0"
+    cells[0].hv.override_net_name = "CELL1"
+    cells[1].hv.override_net_name = "CELL2"
+    cells[2].hv.override_net_name = "CELL3"
+    cells[3].hv.override_net_name = "CELL4"
+    cells[4].hv.override_net_name = "CELL5"
+    cells[5].hv.override_net_name = "CELL6"
+    cells[6].hv.override_net_name = "CELL7"
+    cells[7].hv.override_net_name = "CELL8"
+    cells[8].hv.override_net_name = "CELL9"
+    cells[9].hv.override_net_name = "CELL10"
+    cells[10].hv.override_net_name = "CELL11"
+    cells[11].hv.override_net_name = "CELL12"
+    cells[12].hv.override_net_name = "CELL13"
+    cells[13].hv.override_net_name = "CELL14"
+    cells[14].hv.override_net_name = "CELL15"
+    cells[15].hv.override_net_name = "CELL16"
+
+    sbi.isoSPI_passthru.p.line.override_net_name = "ISOpass_P"
+    sbi.isoSPI_passthru.n.line.override_net_name = "ISOpass_N"
+
+    atopile_logo = new atopile_logo_25x6mm
+
+module TempSensor:
+    # -40~+125 100mW 10kΩ ±1% 0402 NTC Thermistors ROHS
+    power = new ElectricPower
+    output = new ElectricSignal
+
+    r_top = new Resistor
+    r_top.lcsc_id = "C209959"
+    r_bottom = new Resistor
+    r_bottom.resistance = 10kohm +/- 0.1%
+    r_bottom.package = "0402"
+
+    power.hv ~ r_top.p1
+    r_top.p2 ~ r_bottom.p1
+    power.lv ~ r_bottom.p2
+
+    output.line ~ r_top.p2
+    output.reference.lv ~ power.lv
+
+module StackableBMBInterface:
+    cell_power_up = new HRS_DF40HC_3_0__30DS_0_4V_51_package
+    cell_power_down = new HRS_DF40C_30DP_0_4V_51_package
+
+    cell_sense_up = new HRS_DF40HC_3_0__30DS_0_4V_51_package
+    cell_sense_down = new HRS_DF40C_30DP_0_4V_51_package
+
+    signals_up = new HRS_DF40HC_3_0__30DS_0_4V_51_package
+    signals_down = new HRS_DF40C_30DP_0_4V_51_package
+
+    isoSPI_up = new DifferentialPair
+    isoSPI_up.n.line ~ signals_up.29
+    isoSPI_up.p.line ~ signals_up.30
+    isoSPI_down = new DifferentialPair
+    isoSPI_down.n.line ~ signals_down.29
+    isoSPI_down.p.line ~ signals_down.30
+    isoSPI_passthru = new DifferentialPair
+    isoSPI_passthru.n.line ~ signals_up.27
+    isoSPI_passthru.p.line ~ signals_up.28
+    isoSPI_passthru.n.line ~ signals_down.27
+    isoSPI_passthru.p.line ~ signals_down.28
+
+    gpios = new ElectricSignal[10]
+    gpios[0].line ~ signals_down.10
+    gpios[1].line ~ signals_down.11
+    gpios[2].line ~ signals_down.12
+    gpios[3].line ~ signals_down.13
+    gpios[4].line ~ signals_down.14
+    gpios[5].line ~ signals_down.15
+    gpios[6].line ~ signals_down.16
+    gpios[7].line ~ signals_down.17
+    gpios[8].line ~ signals_down.18
+    gpios[9].line ~ signals_down.19
+
+
+    cell_power_down.1 ~ cell_power_up.1
+    cell_power_down.2 ~ cell_power_up.2
+    cell_power_down.3 ~ cell_power_up.3
+    cell_power_down.4 ~ cell_power_up.4
+    cell_power_down.5 ~ cell_power_up.5
+    cell_power_down.6 ~ cell_power_up.6
+    cell_power_down.7 ~ cell_power_up.7
+    cell_power_down.8 ~ cell_power_up.8
+    cell_power_down.9 ~ cell_power_up.9
+    cell_power_down.10 ~ cell_power_up.10
+    cell_power_down.11 ~ cell_power_up.11
+    cell_power_down.12 ~ cell_power_up.12
+    cell_power_down.13 ~ cell_power_up.13
+    cell_power_down.14 ~ cell_power_up.14
+    cell_power_down.15 ~ cell_power_up.15
+    cell_power_down.16 ~ cell_power_up.16
+    cell_power_down.17 ~ cell_power_up.17
+    cell_power_down.18 ~ cell_power_up.18
+    cell_power_down.19 ~ cell_power_up.19
+    cell_power_down.20 ~ cell_power_up.20
+    cell_power_down.21 ~ cell_power_up.21
+    cell_power_down.22 ~ cell_power_up.22
+    cell_power_down.23 ~ cell_power_up.23
+    cell_power_down.24 ~ cell_power_up.24
+    cell_power_down.25 ~ cell_power_up.25
+    cell_power_down.26 ~ cell_power_up.26
+    cell_power_down.27 ~ cell_power_up.27
+    cell_power_down.28 ~ cell_power_up.28
+    cell_power_down.29 ~ cell_power_up.29
+    cell_power_down.30 ~ cell_power_up.30
+
+    cell_sense_down.1 ~ cell_sense_up.1
+    cell_sense_down.2 ~ cell_sense_up.2
+    cell_sense_down.3 ~ cell_sense_up.3
+    cell_sense_down.4 ~ cell_sense_up.4
+    cell_sense_down.5 ~ cell_sense_up.5
+    cell_sense_down.6 ~ cell_sense_up.6
+    cell_sense_down.7 ~ cell_sense_up.7
+    cell_sense_down.8 ~ cell_sense_up.8
+    cell_sense_down.9 ~ cell_sense_up.9
+    cell_sense_down.10 ~ cell_sense_up.10
+    cell_sense_down.11 ~ cell_sense_up.11
+    cell_sense_down.12 ~ cell_sense_up.12
+    cell_sense_down.13 ~ cell_sense_up.13
+    cell_sense_down.14 ~ cell_sense_up.14
+    cell_sense_down.15 ~ cell_sense_up.15
+    cell_sense_down.16 ~ cell_sense_up.16
+    cell_sense_down.17 ~ cell_sense_up.17
+    cell_sense_down.18 ~ cell_sense_up.18
+    cell_sense_down.19 ~ cell_sense_up.19
+    cell_sense_down.20 ~ cell_sense_up.20
+    cell_sense_down.21 ~ cell_sense_up.21
+    cell_sense_down.22 ~ cell_sense_up.22
+    cell_sense_down.23 ~ cell_sense_up.23
+    cell_sense_down.24 ~ cell_sense_up.24
+    cell_sense_down.25 ~ cell_sense_up.25
+    cell_sense_down.26 ~ cell_sense_up.26
+    cell_sense_down.27 ~ cell_sense_up.27
+    cell_sense_down.28 ~ cell_sense_up.28
+    cell_sense_down.29 ~ cell_sense_up.29
+    cell_sense_down.30 ~ cell_sense_up.30
+```

--- a/packages/adi-adxl345/README.md
+++ b/packages/adi-adxl345/README.md
@@ -51,6 +51,7 @@ module Usage:
     i2c_bus ~ accelerometer.i2c
 
     # I2C address is fixed at 0x53 (SDO pin tied to GND)
+
 ```
 
 ## Hardware Features

--- a/packages/adi-adxl375/README.md
+++ b/packages/adi-adxl375/README.md
@@ -16,39 +16,27 @@ The ADXL375 is a small, thin, ultralow power, 3-axis MEMS accelerometer with hig
 ## Usage
 
 ```ato
-#pragma experiment("BRIDGE_CONNECT")
+import ElectricPower
+import I2C
 
-import ElectricPower, SPI, I2C
-from "adi-adxl375.ato" import ADI_ADXL375
+from "atopile/adi-adxl375/adi-adxl375.ato" import ADI_ADXL375
 
 module Usage:
-    """
-    Minimal usage example for ADXL375 high-g accelerometer.
-    Shows basic SPI connection with power supply.
-    """
+    """Minimal example for the ADI_ADXL375 accelerometer."""
 
-    # Power supply
-    power_3v3 = new ElectricPower
-    assert power_3v3.voltage within 3.0V to 3.6V
-
-    # SPI bus
-    spi_bus = new SPI
-
-    # I2C bus (alternative interface)
-    i2c_bus = new I2C
-    assert i2c_bus.frequency within 100kHz to 400kHz
-
-    # Accelerometer instance
+    # Sensor instance
     accelerometer = new ADI_ADXL375
 
-    # Connect power
-    power_3v3 ~ accelerometer.power
+    # Power rail
+    power = new ElectricPower
+    power.voltage = 3.3V
+    power ~ accelerometer.power
 
-    # Connect I2C interface
-    i2c_bus ~ accelerometer.i2c
-
-    # Set I2C address (0x53 when ALT pin is low, 0x1D when high)
+    # I²C bus
+    i2c = new I2C
+    i2c ~ accelerometer.i2c
     accelerometer.i2c.address = 0x53
+
 ```
 
 ## Interface Options

--- a/packages/adi-adxl375/usage.ato
+++ b/packages/adi-adxl375/usage.ato
@@ -1,7 +1,7 @@
 import ElectricPower
 import I2C
 
-from "adi-adxl375.ato" import ADI_ADXL375
+from "atopile/adi-adxl375/adi-adxl375.ato" import ADI_ADXL375
 
 module Usage:
     """Minimal example for the ADI_ADXL375 accelerometer."""

--- a/packages/adi-ds2482s-800/README.md
+++ b/packages/adi-ds2482s-800/README.md
@@ -18,7 +18,7 @@ The DS2482S-800 is an 8-channel I2C-to-1-Wire bus adapter that allows easy conne
 
 import ElectricPower
 import I2C
-from "adi-ds2482s-800.ato" import ADI_DS2482S_800
+from "atopile/adi-ds2482s-800/adi-ds2482s-800.ato" import ADI_DS2482S_800
 
 module Usage:
     """
@@ -43,6 +43,7 @@ module Usage:
     # The 8 1-Wire channels are now available as:
     # ds2482.onewire_channels[0] through ds2482.onewire_channels[7]
     # These can be connected to DS18B20 temperature sensors or other 1-Wire devices
+
 ```
 
 ## Contributing

--- a/packages/adi-ds2482s-800/usage.ato
+++ b/packages/adi-ds2482s-800/usage.ato
@@ -2,7 +2,7 @@
 
 import ElectricPower
 import I2C
-from "adi-ds2482s-800.ato" import ADI_DS2482S_800
+from "atopile/adi-ds2482s-800/adi-ds2482s-800.ato" import ADI_DS2482S_800
 
 module Usage:
     """

--- a/packages/adi-ltc4311/README.md
+++ b/packages/adi-ltc4311/README.md
@@ -21,8 +21,8 @@ The LTC4311 is a rise-time accelerator that provides buffered connections for I2
 
 import ElectricPower
 import ElectricLogic
-
-from "ltc4311.ato" import ADI_LTC4311
+import I2C
+from "atopile/adi-ltc4311/adi-ltc4311.ato" import ADI_LTC4311
 
 module Usage:
     """
@@ -39,12 +39,8 @@ module Usage:
     power_3v3 = new ElectricPower
     power_3v3.voltage = 3.3V +/- 5%
 
-    # Create signal connections for both sides of the buffer
-    controller_sda = new ElectricLogic
-    controller_scl = new ElectricLogic
-
-    device_sda = new ElectricLogic
-    device_scl = new ElectricLogic
+    # Create I2C bus
+    i2c = new I2C
 
     # Instantiate the LTC4311 I2C accelerator
     i2c_buffer = new ADI_LTC4311
@@ -52,12 +48,9 @@ module Usage:
     # Connect power
     power_3v3 ~ i2c_buffer.power
 
-    # Connect signals through the bidirectional buffers
-    controller_sda ~ i2c_buffer.bus1  # SDA buffering
-    controller_scl ~ i2c_buffer.bus2  # SCL buffering
+    # Connect I2C bus
+    i2c ~ i2c_buffer.i2c
 
-    # Enable the device (tied high for always-on operation)
-    i2c_buffer.enable.line ~ power_3v3.vcc
 ```
 
 ## How It Works

--- a/packages/adi-ltc4311/usage.ato
+++ b/packages/adi-ltc4311/usage.ato
@@ -5,7 +5,7 @@
 import ElectricPower
 import ElectricLogic
 import I2C
-from "adi-ltc4311.ato" import ADI_LTC4311
+from "atopile/adi-ltc4311/adi-ltc4311.ato" import ADI_LTC4311
 
 module Usage:
     """

--- a/packages/adi-ltc4316/README.md
+++ b/packages/adi-ltc4316/README.md
@@ -17,17 +17,25 @@ The LTC4316 is a specialized I2C address translator that enables resolving addre
 
 ```ato
 #pragma experiment("TRAITS")
+#pragma experiment("FOR_LOOP")
 import Resistor
 import I2C
 import ElectricPower
 import ElectricLogic
 
-from "adi-ltc4316.ato" import ADI_LTC4316
+from "atopile/adi-ltc4316/adi-ltc4316.ato" import ADI_LTC4316
 
 module Usage:
     """
     Minimal usage example for adi-ltc4316.
     Shows how to use the LTC4316 I2C address translator to resolve address conflicts.
+
+    This example shows:
+    - Basic power supply connection
+    - I2C bus connections (pull-ups included in module)
+    - Enable pin configuration
+    - Address translation configuration using pull-up/down resistors
+    - READY pin monitoring (optional)
     """
 
     # I2C address translator
@@ -43,32 +51,39 @@ module Usage:
     i2c_output = new I2C
 
     # Connect I2C buses
+    # Note: I2C pull-up resistors are built into the translator module
     i2c_input ~ translator.i2c_in
     i2c_output ~ translator.i2c_out
 
-    # Enable the translator - permanently enable with pull-up
-    enable_pullup = new Resistor
-    enable_pullup.resistance = 10kohm +/- 5%
-    enable_pullup.package = "0402"
-    translator.enable.line ~ enable_pullup.unnamed[0]
-    power_3v3.hv ~ enable_pullup.unnamed[1]
+    # Optional: Monitor READY pin status
+    # READY pin has built-in pull-up resistor in translator module
+    ready_status = new ElectricLogic
+    ready_status ~ translator.ready
 
     # Configure address translation with pull-up/down resistors
     # XOR configuration resistors determine address translation
-    power_3v3 ~ translator.xor_high.reference
-    power_3v3 ~ translator.xor_low.reference
+    # This example configuration: XORH=HIGH, XORL=LOW
+    # Result: Flips address bits A6 (always) + A5 (from XORH=HIGH)
 
+    # XORH pull-up: sets upper address bits in XOR mask
     xor_high_pullup = new Resistor
     xor_high_pullup.resistance = 10kohm +/- 5%
     xor_high_pullup.package = "0402"
     translator.xor_high.line ~ xor_high_pullup.unnamed[0]
     power_3v3.hv ~ xor_high_pullup.unnamed[1]
 
+    # XORL pull-down: clears lower address bit in XOR mask
     xor_low_pulldown = new Resistor
     xor_low_pulldown.resistance = 10kohm +/- 5%
     xor_low_pulldown.package = "0402"
     translator.xor_low.line ~ xor_low_pulldown.unnamed[0]
     power_3v3.lv ~ xor_low_pulldown.unnamed[1]
+
+    # Address translation examples with this configuration:
+    # Input 0x38 (AHT20) -> Output 0x78 (bits A6+A5 flipped)
+    # Input 0x76 (BME280) -> Output 0x36 (bits A6+A5 flipped)
+    # To reset translation: toggle ENABLE pin low then high
+
 ```
 
 ## Address Translation Configuration

--- a/packages/adi-ltc4316/usage.ato
+++ b/packages/adi-ltc4316/usage.ato
@@ -5,7 +5,7 @@ import I2C
 import ElectricPower
 import ElectricLogic
 
-from "adi-ltc4316.ato" import ADI_LTC4316
+from "atopile/adi-ltc4316/adi-ltc4316.ato" import ADI_LTC4316
 
 module Usage:
     """

--- a/packages/ams-tsl2591/README.md
+++ b/packages/ams-tsl2591/README.md
@@ -18,7 +18,7 @@ Advanced digital light sensor with ultra-high sensitivity and 600M:1 dynamic ran
 import I2C
 import ElectricPower
 
-from "ams-tsl2591.ato" import AMS_TSL2591
+from "atopile/ams-tsl2591/ams-tsl2591.ato" import AMS_TSL2591
 
 module Usage:
     """
@@ -40,6 +40,7 @@ module Usage:
     # Connect sensor to power and I2C
     power_3v3 ~ light_sensor.power
     i2c_bus ~ light_sensor.i2c
+
 ```
 
 ## Technical Specifications

--- a/packages/ams-tsl2591/usage.ato
+++ b/packages/ams-tsl2591/usage.ato
@@ -2,7 +2,7 @@
 import I2C
 import ElectricPower
 
-from "ams-tsl2591.ato" import AMS_TSL2591
+from "atopile/ams-tsl2591/ams-tsl2591.ato" import AMS_TSL2591
 
 module Usage:
     """

--- a/packages/aosong-aht20/README.md
+++ b/packages/aosong-aht20/README.md
@@ -22,7 +22,7 @@ A comprehensive atopile package for the Aosong AHT20 digital temperature and hum
 import ElectricPower
 import I2C
 
-from "aosong-aht20.ato" import Aosong_AHT20
+from "atopile/aosong-aht20/aosong-aht20.ato" import Aosong_AHT20
 
 module Usage:
     """
@@ -49,6 +49,7 @@ module Usage:
 
     # The AHT20 has a fixed I2C address of 0x38
     assert sensor.i2c.address is 0x38
+
 ```
 
 ## Hardware Features

--- a/packages/aosong-aht20/usage.ato
+++ b/packages/aosong-aht20/usage.ato
@@ -5,7 +5,7 @@
 import ElectricPower
 import I2C
 
-from "aosong-aht20.ato" import Aosong_AHT20
+from "atopile/aosong-aht20/aosong-aht20.ato" import Aosong_AHT20
 
 module Usage:
     """

--- a/packages/awinic-aw9523/README.md
+++ b/packages/awinic-aw9523/README.md
@@ -45,7 +45,7 @@ import ElectricPower
 import ElectricLogic
 import I2C
 
-from "awinic-aw9523.ato" import Awinic_AW9523
+from "atopile/awinic-aw9523/awinic-aw9523.ato" import Awinic_AW9523
 
 module Usage:
     """
@@ -88,6 +88,7 @@ module Usage:
     gpio_expander.gpios[9] ~ button_input[1]
     gpio_expander.gpios[10] ~ button_input[2]
     gpio_expander.gpios[11] ~ button_input[3]
+
 ```
 
 ## Important Notes

--- a/packages/awinic-aw9523/usage.ato
+++ b/packages/awinic-aw9523/usage.ato
@@ -5,7 +5,7 @@ import ElectricPower
 import ElectricLogic
 import I2C
 
-from "awinic-aw9523.ato" import Awinic_AW9523
+from "atopile/awinic-aw9523/awinic-aw9523.ato" import Awinic_AW9523
 
 module Usage:
     """

--- a/packages/bosch-bme280/README.md
+++ b/packages/bosch-bme280/README.md
@@ -14,16 +14,17 @@ import ElectricPower
 import I2C
 
 # --- Package import ---
-from "bosch-bme280.ato" import Bosch_BME280
+from "atopile/bosch-bme280/bosch-bme280.ato" import Bosch_BME280
+
 
 module Usage:
     """
     Minimal usage example for `bosch-bme280`.
     Powers the BME280 from a 3 V 3 rail and places it on an I²C bus at the
-    default 7-bit address (0x76).
+    default address **0x76**.
     """
 
-    # Power rail (3.3 V) – shared by core & I/O
+    # Power rail (3.3 V shared for core & I/O)
     power_3v3 = new ElectricPower
     power_3v3.voltage = 3.3V
 
@@ -33,7 +34,7 @@ module Usage:
     # Sensor instance
     sensor = new Bosch_BME280
 
-    # Connect power rails
+    # Connect required power rails
     power_3v3 ~ sensor.power_core
     power_3v3 ~ sensor.power_io
 
@@ -46,6 +47,7 @@ module Usage:
 
     # (Optional) Select address – defaults to 0x76 (SDO=0)
     sensor.i2c.address = 0x76
+
 ```
 
 ## Contributing

--- a/packages/bosch-bme680/README.md
+++ b/packages/bosch-bme680/README.md
@@ -9,7 +9,7 @@ The BME680 is a digital 4-in-1 sensor with gas, humidity, pressure and temperatu
 import I2C
 import ElectricPower
 
-from "bosch-bme680.ato" import Bosch_BME680
+from "atopile/bosch-bme680/bosch-bme680.ato" import Bosch_BME680
 
 module Usage:
     """
@@ -42,6 +42,7 @@ module Usage:
     # - Protocol selection (I2C default)
     # - Dual rail support (VDD/VDDIO internally connected)
     assert sensor.i2c.address is 0x76
+
 ```
 
 ## Features

--- a/packages/bosch-bme680/usage.ato
+++ b/packages/bosch-bme680/usage.ato
@@ -2,7 +2,7 @@
 import I2C
 import ElectricPower
 
-from "bosch-bme680.ato" import Bosch_BME680
+from "atopile/bosch-bme680/bosch-bme680.ato" import Bosch_BME680
 
 module Usage:
     """

--- a/packages/bosch-bme688/README.md
+++ b/packages/bosch-bme688/README.md
@@ -21,12 +21,15 @@ The Bosch BME688 is a 4-in-1 environmental sensor that measures temperature, hum
 import I2C
 import ElectricPower
 
-from "bosch-bme688.ato" import Bosch_BME688
+from "atopile/bosch-bme688/bosch-bme688.ato" import Bosch_BME688
 
 module Usage:
     """
-    Minimal usage example for bosch-bme688.
+    Usage example for bosch-bme688.
     Shows how to connect the BME688 sensor with I2C interface and power supply.
+
+    The sensor comes with built-in I2C pull-ups and power filtering.
+    Just connect power and I2C bus - everything else is handled automatically.
     """
 
     # Create sensor instance
@@ -34,18 +37,23 @@ module Usage:
 
     # Create I2C bus
     i2c = new I2C
-    i2c.frequency = 100kHz
+    i2c.frequency = 400kHz  # Fast mode I2C
 
     # Create power supply
     power = new ElectricPower
-    power.voltage = 3.3V
+    power.voltage = 3.3V  # Recommended voltage
 
-    # Connect interfaces
+    # Connect interfaces - that's it!
     i2c ~ sensor.i2c
     power ~ sensor.power
 
-    # Set I2C address (0x76 or 0x77 depending on SDO pin)
-    assert sensor.i2c.address is 0x76
+    # Address will be 0x77 (SDO floating) or 0x76 (SDO to GND)
+    # Built-in features automatically included:
+    # - I2C pull-ups (4.7kΩ)
+    # - Power filtering (100nF + 10nF caps)
+    # - Protocol selection (I2C default)
+    assert sensor.i2c.address is 0x77
+
 ```
 
 ## I2C Address Configuration

--- a/packages/bosch-bme688/usage.ato
+++ b/packages/bosch-bme688/usage.ato
@@ -2,7 +2,7 @@
 import I2C
 import ElectricPower
 
-from "bosch-bme688.ato" import Bosch_BME688
+from "atopile/bosch-bme688/bosch-bme688.ato" import Bosch_BME688
 
 module Usage:
     """

--- a/packages/bosch-bmp280/README.md
+++ b/packages/bosch-bmp280/README.md
@@ -23,29 +23,38 @@ The BMP280 is a digital temperature and pressure sensor featuring high accuracy 
 import ElectricPower
 import I2C
 
-from "bosch-bmp280.ato" import Bosch_BMP280
+from "atopile/bosch-bmp280/bosch-bmp280.ato" import Bosch_BMP280
 
 module Usage:
     """
     Minimal usage example for bosch-bmp280.
-    Shows basic I²C connection and power supply.
+    Demonstrates basic I²C connection with 3.3V power supply.
+    The sensor will be configured at I2C address 0x76 (SDO pin pulled low).
     """
 
+    # Sensor instance
     sensor = new Bosch_BMP280
 
-    # Connect external I²C bus
+    # External I²C bus
     i2c = new I2C
+    """External I2C bus for sensor communication"""
     i2c ~ sensor.i2c
 
-    # Connect power supplies
+    # Power supply (3.3V rail for both core and I/O)
     power_3v3 = new ElectricPower
     power_3v3.voltage = 3.3V +/- 5%
 
+    # Connect both power rails to the same 3.3V supply
     power_3v3 ~ sensor.power_core
     power_3v3 ~ sensor.power_io
 
-    # Set I²C address to 0x76 (SDO pulled low)
-    assert sensor.i2c.address is 0x76
+    # Provide I2C bus reference voltage
+    power_3v3 ~ i2c.scl.reference
+    power_3v3 ~ i2c.sda.reference
+
+    # Configure I²C address to 0x76 (SDO pin will be pulled low via internal pull-down)
+    sensor.i2c.address = 0x76
+
 ```
 
 ## Interface Details

--- a/packages/bosch-bmp280/usage.ato
+++ b/packages/bosch-bmp280/usage.ato
@@ -5,7 +5,7 @@
 import ElectricPower
 import I2C
 
-from "bosch-bmp280.ato" import Bosch_BMP280
+from "atopile/bosch-bmp280/bosch-bmp280.ato" import Bosch_BMP280
 
 module Usage:
     """

--- a/packages/bosch-bmp388/README.md
+++ b/packages/bosch-bmp388/README.md
@@ -40,6 +40,7 @@ module Usage:
 
     # Set I²C address to 0x76 (SDO pulled low)
     assert sensor.i2c.address is 0x76
+
 ```
 
 ## Contributing

--- a/packages/diodes-inc-74lvc1t45dw-7/README.md
+++ b/packages/diodes-inc-74lvc1t45dw-7/README.md
@@ -24,7 +24,7 @@ The 74LVC1T45DW-7 is a single-bit, dual-supply bus transceiver that provides bid
 import ElectricPower
 import ElectricLogic
 
-from "diodes-inc-74lvc1t45dw-7.ato" import Diodes_Inc_74LVC1T45DW_7, Level_Shifter_3V3_to_5V, Bidirectional_Level_Shifter
+from "atopile/diodes-inc-74lvc1t45dw-7/diodes-inc-74lvc1t45dw-7.ato" import Diodes_Inc_74LVC1T45DW_7, Level_Shifter_3V3_to_5V, Bidirectional_Level_Shifter
 
 module Usage:
     """
@@ -80,6 +80,89 @@ module Usage:
     """SPI clock to 5V display"""
     display_spi_clock ~ preconfigured_shifter.signal_5v
     power_5v ~ display_spi_clock.reference
+
+    # --- Bidirectional Level Shifter Example ---
+    bidir_shifter = new Bidirectional_Level_Shifter
+
+    # Connect power supplies
+    power_3v3 ~ bidir_shifter.power_low
+    power_5v ~ bidir_shifter.power_high
+
+    # Bidirectional data line (e.g., I2C SDA)
+    mcu_data = new ElectricLogic
+    """Bidirectional data from MCU"""
+    mcu_data ~ bidir_shifter.signal_low
+    power_3v3 ~ mcu_data.reference
+
+    sensor_data = new ElectricLogic
+    """Bidirectional data to/from sensor"""
+    sensor_data ~ bidir_shifter.signal_high
+    power_5v ~ sensor_data.reference
+
+    # Direction control from MCU
+    direction_ctrl = new ElectricLogic
+    """Direction control signal"""
+    direction_ctrl ~ bidir_shifter.direction_control
+    power_3v3 ~ direction_ctrl.reference
+
+    # --- Multiple Level Shifters for Bus Translation ---
+    # Example: Converting 4-bit bus from 3.3V to 5V
+    bus_shifters = new Diodes_Inc_74LVC1T45DW_7[4]
+
+    # Connect power to all shifters
+    for shifter in bus_shifters:
+        power_3v3 ~ shifter.power_a
+        power_5v ~ shifter.power_b
+
+    # Create bus signals
+    mcu_bus = new ElectricLogic[4]
+    """4-bit bus from MCU (3.3V)"""
+
+    peripheral_bus = new ElectricLogic[4]
+    """4-bit bus to peripheral (5V)"""
+
+    # Connect bus signals through shifters
+    mcu_bus[0] ~ bus_shifters[0].signal_a; peripheral_bus[0] ~ bus_shifters[0].signal_b
+    mcu_bus[1] ~ bus_shifters[1].signal_a; peripheral_bus[1] ~ bus_shifters[1].signal_b
+    mcu_bus[2] ~ bus_shifters[2].signal_a; peripheral_bus[2] ~ bus_shifters[2].signal_b
+    mcu_bus[3] ~ bus_shifters[3].signal_a; peripheral_bus[3] ~ bus_shifters[3].signal_b
+
+    # Set signal references
+    for bus_signal in mcu_bus:
+        power_3v3 ~ bus_signal.reference
+    for bus_signal in peripheral_bus:
+        power_5v ~ bus_signal.reference
+
+    # --- UART Level Shifting Example ---
+    uart_tx_shifter = new Diodes_Inc_74LVC1T45DW_7
+    uart_rx_shifter = new Diodes_Inc_74LVC1T45DW_7
+
+    # Connect power
+    power_3v3 ~ uart_tx_shifter.power_a
+    power_5v ~ uart_tx_shifter.power_b
+    power_3v3 ~ uart_rx_shifter.power_a
+    power_5v ~ uart_rx_shifter.power_b
+
+    # UART TX (MCU to peripheral): 3.3V -> 5V
+    mcu_uart_tx = new ElectricLogic
+    peripheral_uart_rx = new ElectricLogic
+    mcu_uart_tx ~ uart_tx_shifter.signal_a
+    peripheral_uart_rx ~ uart_tx_shifter.signal_b
+    uart_tx_shifter.dir.line ~ power_3v3.vcc  # A -> B direction
+
+    # UART RX (peripheral to MCU): 5V -> 3.3V
+    peripheral_uart_tx = new ElectricLogic
+    mcu_uart_rx = new ElectricLogic
+    mcu_uart_rx ~ uart_rx_shifter.signal_a
+    peripheral_uart_tx ~ uart_rx_shifter.signal_b
+    uart_rx_shifter.dir.line ~ power_3v3.gnd  # B -> A direction
+
+    # Set signal references
+    power_3v3 ~ mcu_uart_tx.reference
+    power_3v3 ~ mcu_uart_rx.reference
+    power_5v ~ peripheral_uart_rx.reference
+    power_5v ~ peripheral_uart_tx.reference
+
 ```
 
 ## Technical Specifications

--- a/packages/diodes-inc-74lvc1t45dw-7/usage.ato
+++ b/packages/diodes-inc-74lvc1t45dw-7/usage.ato
@@ -5,7 +5,7 @@
 import ElectricPower
 import ElectricLogic
 
-from "diodes-inc-74lvc1t45dw-7.ato" import Diodes_Inc_74LVC1T45DW_7, Level_Shifter_3V3_to_5V, Bidirectional_Level_Shifter
+from "atopile/diodes-inc-74lvc1t45dw-7/diodes-inc-74lvc1t45dw-7.ato" import Diodes_Inc_74LVC1T45DW_7, Level_Shifter_3V3_to_5V, Bidirectional_Level_Shifter
 
 module Usage:
     """

--- a/packages/indicator-leds/README.md
+++ b/packages/indicator-leds/README.md
@@ -30,6 +30,7 @@ module Usage:
 
     # Bridge connect across the power rail
     power.hv ~> green_led ~> power.lv
+
 ```
 
 ## Contributing

--- a/packages/infineon-dps310/README.md
+++ b/packages/infineon-dps310/README.md
@@ -16,7 +16,7 @@ and temperature sensor.
 import ElectricPower
 import I2C
 
-from "atopile/sensirion-scd40/sensirion-scd40.ato" import Sensirion_SCD40
+from "atopile/infineon-dps310/infineon-dps310.ato" import Infineon_DPS310
 
 module MCU:
     """Host MCU providing I²C bus and power rail."""
@@ -26,20 +26,21 @@ module MCU:
 
 
 module Usage:
-    """Minimal example for the Sensirion_SCD40 CO₂ sensor."""
+    """Minimal example for the Infineon_DPS310 barometric pressure and altitude sensor."""
 
     # MCU & sensor
     mcu = new MCU
-    co2_sensor = new Sensirion_SCD40
+    pressure_sensor = new Infineon_DPS310
 
     # Shared 3V3 rail
     power = new ElectricPower
     power.voltage = 3.3V
     power ~ mcu.power
-    power ~ co2_sensor.power
+    power ~ pressure_sensor.power
 
     # I²C connection
-    mcu.i2c ~ co2_sensor.i2c
+    mcu.i2c ~ pressure_sensor.i2c
+
 ```
 
 ## Contributing

--- a/packages/infineon-dps310/usage.ato
+++ b/packages/infineon-dps310/usage.ato
@@ -1,7 +1,7 @@
 import ElectricPower
 import I2C
 
-from "infineon-dps310.ato" import Infineon_DPS310
+from "atopile/infineon-dps310/infineon-dps310.ato" import Infineon_DPS310
 
 module MCU:
     """Host MCU providing I²C bus and power rail."""

--- a/packages/invensense-icm20948/README.md
+++ b/packages/invensense-icm20948/README.md
@@ -28,7 +28,8 @@ import I2C
 import ElectricPower
 import ElectricLogic
 
-from "invensense-icm20948.ato" import ICM20948
+from "atopile/invensense-icm20948/invensense-icm20948.ato" import Invensense_ICM20948
+
 
 module Usage:
     """
@@ -37,7 +38,7 @@ module Usage:
     """
 
     # --- IMU sensor ---
-    imu = new ICM20948
+    imu = new Invensense_ICM20948
 
     # --- Power supplies ---
     power_3v3 = new ElectricPower  # Core power (VDD)
@@ -61,6 +62,7 @@ module Usage:
     i2c_bus ~ imu.i2c
     interrupt_pin ~ imu.interrupt
     frame_sync ~ imu.fsync
+
 ```
 
 ## Interfaces

--- a/packages/invensense-icm20948/usage.ato
+++ b/packages/invensense-icm20948/usage.ato
@@ -6,7 +6,7 @@ import I2C
 import ElectricPower
 import ElectricLogic
 
-from "invensense-icm20948.ato" import Invensense_ICM20948
+from "atopile/invensense-icm20948/invensense-icm20948.ato" import Invensense_ICM20948
 
 
 module Usage:

--- a/packages/invensense-mpu6050/README.md
+++ b/packages/invensense-mpu6050/README.md
@@ -11,17 +11,28 @@ This package provides an ato driver that models the device for use in Atopile pr
 
 import ElectricPower
 import I2C
-from "invensense-mpu6050.ato" import Invensense_MPU6050
+from "atopile/invensense-mpu6050/invensense-mpu6050.ato" import Invensense_MPU6050
 
-module Demo:
-    power = new ElectricPower
-    i2c = new I2C
+module Usage:
+    """Minimal usage example for `invensense-mpu6050`.
+    Shows how to wire the IMU to a shared 3V3 power rail and I²C bus.
+    """
 
+    # Shared rails / busses
+    power_3v3 = new ElectricPower
+    i2c_bus = new I2C
+
+    # IMU instance
     imu = new Invensense_MPU6050
 
-    imu.power_core ~ power
-    imu.power_io ~ power
-    imu.i2c ~ i2c
+    # Connections
+    imu.power_core ~ power_3v3
+    imu.power_io ~ power_3v3
+    imu.i2c ~ i2c_bus
+
+    # Configure I²C address (AD0 pulled low => 0x68)
+    i2c_bus.address = 0x68
+
 ```
 
 ## PCB footprints & symbol

--- a/packages/invensense-mpu6050/usage.ato
+++ b/packages/invensense-mpu6050/usage.ato
@@ -2,7 +2,7 @@
 
 import ElectricPower
 import I2C
-from "invensense-mpu6050.ato" import Invensense_MPU6050
+from "atopile/invensense-mpu6050/invensense-mpu6050.ato" import Invensense_MPU6050
 
 module Usage:
     """Minimal usage example for `invensense-mpu6050`.

--- a/packages/issi-is31fl3731/README.md
+++ b/packages/issi-is31fl3731/README.md
@@ -5,18 +5,59 @@
 ## Usage
 
 ```ato
-import ElectricPower, I2C
-from "issi-is31fl3731.ato" import ISSI_IS31FL3731
+#pragma experiment("MODULE_TEMPLATING")
+#pragma experiment("BRIDGE_CONNECT")
+#pragma experiment("FOR_LOOP")
 
-module Example:
-    rail = new ElectricPower
-    rail.voltage = 3.3V
+import ElectricPower
+import I2C
+import Electrical
+import ElectricLogic
+import LED
 
-    bus = new I2C
+from "atopile/issi-is31fl3731/issi-is31fl3731.ato" import ISSI_IS31FL3731
 
-    driver = new ISSI_IS31FL3731
-    rail ~ driver.power
-    bus ~ driver.i2c
+module MCU:
+    """Host microcontroller providing I²C and 3.3 V rail."""
+    power = new ElectricPower
+    i2c = new I2C
+    irq = new ElectricLogic
+
+module Usage:
+    """Minimal usage example for ISSI_IS31FL3731 LED matrix driver."""
+
+    mcu = new MCU
+    led_driver = new ISSI_IS31FL3731
+    row_0_led = new LED[8]
+    # ... more rows ...
+
+    # power
+    power = new ElectricPower
+    power.voltage = 3.3V
+    power ~ mcu.power
+    power ~ led_driver.power
+
+    # I²C connection
+    mcu.i2c ~ led_driver.i2c
+
+    # Interrupt line (optional)
+    led_driver.interrupt ~ mcu.irq
+
+    # leds
+    for led in row_0_led:
+        led.lcsc_id = "C2286"
+        led_driver.channel_a[0].line ~ led.cathode
+    led_driver.channel_a[1].line ~ row_0_led[0].anode
+    led_driver.channel_a[2].line ~ row_0_led[1].anode
+    led_driver.channel_a[3].line ~ row_0_led[2].anode
+    led_driver.channel_a[4].line ~ row_0_led[3].anode
+    led_driver.channel_a[5].line ~ row_0_led[4].anode
+    led_driver.channel_a[6].line ~ row_0_led[5].anode
+    led_driver.channel_a[7].line ~ row_0_led[6].anode
+    led_driver.channel_a[8].line ~ row_0_led[7].anode
+
+    # ... more rows ...
+
 ```
 
 `driver.interrupt` can be wired to an MCU GPIO for frame-sync or

--- a/packages/issi-is31fl3731/usage.ato
+++ b/packages/issi-is31fl3731/usage.ato
@@ -8,7 +8,7 @@ import Electrical
 import ElectricLogic
 import LED
 
-from "issi-is31fl3731.ato" import ISSI_IS31FL3731
+from "atopile/issi-is31fl3731/issi-is31fl3731.ato" import ISSI_IS31FL3731
 
 module MCU:
     """Host microcontroller providing I²C and 3.3 V rail."""

--- a/packages/liteon-ltr303/README.md
+++ b/packages/liteon-ltr303/README.md
@@ -33,6 +33,7 @@ module Usage:
 
     # I²C connection
     mcu.i2c ~ ambient_light_sensor.i2c
+
 ```
 
 ## Contributing

--- a/packages/liteon-ltr329/README.md
+++ b/packages/liteon-ltr329/README.md
@@ -33,6 +33,7 @@ module Usage:
 
     # I²C connection
     mcu.i2c ~ ambient_light_sensor.i2c
+
 ```
 
 ## Contributing

--- a/packages/liteon-ltr390uv/README.md
+++ b/packages/liteon-ltr390uv/README.md
@@ -9,7 +9,7 @@ hardware connections so you can drop it into your design effortlessly.
 import ElectricPower
 import I2C
 
-from "atopile/liteon-ltr329/liteon-ltr329.ato" import Liteon_LTR329
+from "atopile/liteon-ltr390uv/liteon-ltr390uv.ato" import Liteon_LTR390UV
 
 module MCU:
     """Host MCU providing I²C bus and power rail."""
@@ -19,20 +19,21 @@ module MCU:
 
 
 module Usage:
-    """Minimal example for the Liteon_LTR329 ambient light sensor."""
+    """Minimal example for the Liteon_LTR390UV UV sensor."""
 
     # MCU & sensor
     mcu = new MCU
-    ambient_light_sensor = new Liteon_LTR329
+    uv_sensor = new Liteon_LTR390UV
 
     # Shared 3V3 rail
     power = new ElectricPower
     power.voltage = 3.3V
     power ~ mcu.power
-    power ~ ambient_light_sensor.power
+    power ~ uv_sensor.power
 
     # I²C connection
-    mcu.i2c ~ ambient_light_sensor.i2c
+    mcu.i2c ~ uv_sensor.i2c
+
 ```
 
 ## Contributing

--- a/packages/maxim-ds1841/README.md
+++ b/packages/maxim-ds1841/README.md
@@ -26,33 +26,50 @@ fine resolution is required at the low-resistance end.
 
 ## Usage Example
 ```ato
-#pragma experiment("BRIDGE_CONNECT")
-#pragma experiment("FOR_LOOP")
+import ElectricPower
+import I2C
+import Electrical
 
-import ElectricPower, I2C, Electrical
-from "maxim-ds1841.ato" import Maxim_DS1841
+from "atopile/maxim-ds1841/maxim-ds1841.ato" import Maxim_DS1841
 
-module Demo:
-    # 3 V3 rail
-    rail_3v3 = new ElectricPower
-    rail_3v3.voltage = 3.3V +/- 5%
+# Example MCU providing I²C bus and reading the wiper voltage with an ADC pin
+module MCU:
+    power = new ElectricPower
+    i2c = new I2C
+    adc_in = new Electrical
 
-    # I²C bus @ 400 kHz, address 0x28 (A1=A0=0)
-    bus = new I2C
-    bus.frequency = 400kHz
-    bus.address = 0x28
+module Usage:
+    """
+    Minimal wiring for the Maxim DS1841 logarithmic digital potentiometer (22 kΩ to 3.7 kΩ) used as a programmable voltage divider.
 
+    1. The potentiometer top end (`RH`) is tied to 3V3, bottom end (`RL`) to GND.
+    2. The wiper (`RW`) is routed to an MCU ADC input so firmware can read the
+       divided voltage and the DS3502 can trim it over I²C.
+    3. Address pins `A1:A0` are left low which selects I²C address 0x28.
+    """
+
+    # MCU with I²C and ADC capabilities
+    mcu = new MCU
+
+    # DS1841 instance
     pot = new Maxim_DS1841
 
-    rail_3v3 ~ pot.power
-    bus     ~ pot.i2c
+    # Shared 3 V3 rail
+    power_3v3 = new ElectricPower
+    power_3v3.voltage = 3.3V +/- 5%
 
-    # Divider configuration: RH = 3 V3, RGND = GND, RW = output
-    rail_3v3.hv ~ pot.potentiometer_high.line   # RH
-    rail_3v3.lv ~ pot.potentiometer_low.line    # RGND
+    # I²C bus (Fast-mode, 400 kHz)
+    i2c_bus = new I2C
+    pot.i2c.address = 0x28  # A1=A0=0 on DS1841
 
-    v_out = new Electrical
-    v_out ~ pot.potentiometer_wiper.line        # RW
+    # Power distribution
+    power_3v3 ~ mcu.power
+    power_3v3 ~ pot.power
+
+    # Connect I²C
+    i2c_bus ~ mcu.i2c
+    i2c_bus ~ pot.i2c
+
 ```
 
 ## License

--- a/packages/maxim-ds2484/README.md
+++ b/packages/maxim-ds2484/README.md
@@ -24,7 +24,7 @@ The DS2484 is a single-channel 1-Wire master with an I2C interface from Maxim In
 import ElectricPower
 import I2C
 
-from "maxim-ds2484.ato" import Maxim_DS2484, OneWire
+from "atopile/maxim-ds2484/maxim-ds2484.ato" import Maxim_DS2484, OneWire
 
 module TemperatureSensor:
     """
@@ -59,6 +59,7 @@ module Usage:
 
     # Set I2C address (default 0x18)
     bridge.i2c.address = 0x18
+
 ```
 
 ## Technical Specifications

--- a/packages/maxim-ds2484/usage.ato
+++ b/packages/maxim-ds2484/usage.ato
@@ -3,7 +3,7 @@
 import ElectricPower
 import I2C
 
-from "maxim-ds2484.ato" import Maxim_DS2484, OneWire
+from "atopile/maxim-ds2484/maxim-ds2484.ato" import Maxim_DS2484, OneWire
 
 module TemperatureSensor:
     """

--- a/packages/maxim-ds3231/README.md
+++ b/packages/maxim-ds3231/README.md
@@ -11,18 +11,56 @@ Features:
 
 ## Usage
 ```ato
-from "maxim-ds3231.ato" import Maxim_DS3231
-import ElectricPower, I2C
+#pragma experiment("FOR_LOOP")
 
-module Demo:
-    rail_3v3 = new ElectricPower
-    rail_3v3.voltage = 3.3V
+import ElectricPower
+import I2C
+import ElectricLogic
+from "atopile/maxim-ds3231/maxim-ds3231.ato" import Maxim_DS3231
+from "parts/Q_J_CR1220_2/Q_J_CR1220_2.ato" import Q_J_CR1220_2_package
 
-    bus = new I2C
+module MCU:
+    """Host microcontroller providing I²C bus and 3.3 V rail."""
+
+    power = new ElectricPower
+    i2c = new I2C
+    irq = new ElectricLogic
+
+module Usage:
+    """Minimal usage example for Maxim DS3231 RTC."""
+
+    # Instantiate MCU and RTC
+    mcu = new MCU
+
+    # Shared 3.3 V rail
+    power = new ElectricPower
+    power.voltage = 3.3V +/- 5%
+
+    # Backup battery holder (CR1220 coin cell)
+    battery_holder = new Q_J_CR1220_2_package
+
+    backup_rail = new ElectricPower
+    backup_rail.voltage = 3.0V +/- 10%
+
+    # Connect battery holder to backup rail
+    backup_rail.hv ~ battery_holder.1
+    backup_rail.lv ~ battery_holder.2
+
     rtc = new Maxim_DS3231
 
-    rail_3v3 ~ rtc.power
-    bus ~ rtc.i2c
+    # Power distribution
+    power ~ mcu.power
+    power ~ rtc.power
+
+    # I²C connection
+    mcu.i2c ~ rtc.i2c
+
+    # Optional interrupt line
+    rtc.square_interrupt ~ mcu.irq
+
+    # Connect backup rail to RTC
+    backup_rail ~ rtc.backup_power
+
 ```
 
 ## Contributing

--- a/packages/maxim-ds3231/usage.ato
+++ b/packages/maxim-ds3231/usage.ato
@@ -3,7 +3,7 @@
 import ElectricPower
 import I2C
 import ElectricLogic
-from "maxim-ds3231.ato" import Maxim_DS3231
+from "atopile/maxim-ds3231/maxim-ds3231.ato" import Maxim_DS3231
 from "parts/Q_J_CR1220_2/Q_J_CR1220_2.ato" import Q_J_CR1220_2_package
 
 module MCU:

--- a/packages/maxim-ds3502/README.md
+++ b/packages/maxim-ds3502/README.md
@@ -27,37 +27,50 @@ This package wraps the raw IC in a reusable Ato **module** that exposes:
 ## Usage
 
 ```ato
-#pragma experiment("BRIDGE_CONNECT")
-#pragma experiment("FOR_LOOP")
+import ElectricPower
+import I2C
+import Electrical
 
-import ElectricPower, I2C, Electrical
-from "maxim-ds3502.ato" import Maxim_DS3502
+from "atopile/maxim-ds3502/maxim-ds3502.ato" import Maxim_DS3502
 
-module Demo:
-    """DS3502 used as programmable divider between 3V3 and GND"""
+# Example MCU providing I²C bus and reading the wiper voltage with an ADC pin
+module MCU:
+    power = new ElectricPower
+    i2c = new I2C
+    adc_in = new Electrical
 
-    # Shared rail
-    rail_3v3 = new ElectricPower
-    rail_3v3.voltage = 3.3V +/- 5%
+module Usage:
+    """
+    Minimal wiring for the Maxim DS3502 (10 kΩ) used as a programmable voltage divider.
 
-    # I²C bus @ 400 kHz, address 0x28 (A1=A0=0)
+    1. The potentiometer top end (`RH`) is tied to 3V3, bottom end (`RL`) to GND.
+    2. The wiper (`RW`) is routed to an MCU ADC input so firmware can read the
+       divided voltage and the DS3502 can trim it over I²C.
+    3. Address pins `A1:A0` are left low which selects I²C address 0x28.
+    """
+
+    # MCU with I²C and ADC capabilities
+    mcu = new MCU
+
+    # Shared 3 V3 rail
+    power_3v3 = new ElectricPower
+    power_3v3.voltage = 3.3V +/- 5%
+
+    # I²C bus (Fast-mode, 400 kHz)
     i2c_bus = new I2C
-    i2c_bus.frequency = 400kHz
-    i2c_bus.address = 0x28
+    i2c_bus.address = 0x28  # A1=A0=0 on DS3502
 
     # DS3502 instance
     pot = new Maxim_DS3502
 
-    # Connect power and control
-    rail_3v3 ~ pot.power
-    i2c_bus  ~ pot.i2c
+    # Power distribution
+    power_3v3 ~ mcu.power
+    power_3v3 ~ pot.power
 
-    # Wire RH to 3V3, RL to GND, take RW as output
-    rail_3v3.hv ~ pot.potentiometer_high.line   # RH
-    rail_3v3.lv ~ pot.potentiometer_low.line    # RL
+    # Connect I²C
+    i2c_bus ~ mcu.i2c
+    i2c_bus ~ pot.i2c
 
-    divider_out = new Electrical
-    divider_out ~ pot.potentiometer_wiper.line  # RW
 ```
 
 ## LCSC Part Information

--- a/packages/maxim-ds3502/usage.ato
+++ b/packages/maxim-ds3502/usage.ato
@@ -2,7 +2,7 @@ import ElectricPower
 import I2C
 import Electrical
 
-from "maxim-ds3502.ato" import Maxim_DS3502
+from "atopile/maxim-ds3502/maxim-ds3502.ato" import Maxim_DS3502
 
 # Example MCU providing I²C bus and reading the wiper voltage with an ADC pin
 module MCU:

--- a/packages/maxim-max17048/README.md
+++ b/packages/maxim-max17048/README.md
@@ -20,8 +20,12 @@ This fuel gauge decodes the non-linear battery voltage to calculate accurate cha
 #pragma experiment("BRIDGE_CONNECT")
 #pragma experiment("TRAITS")
 
-import ElectricPower, I2C from "atopile/generics/interfaces.ato"
-from "maxim-max17048.ato" import Maxim_MAX17048
+import ElectricPower
+import I2C
+from "atopile/maxim-max17048/maxim-max17048.ato" import Maxim_MAX17048
+
+module Battery:
+    power = new ElectricPower
 
 module Usage:
     """
@@ -45,6 +49,9 @@ module Usage:
 
     # Battery connections (would connect to actual battery terminals)
     # Note: In real application, these would connect to your LiPoly/LiIon battery
+    battery = new Battery
+    battery.power ~ fuel_gauge.battery_interface
+
 ```
 
 ## Contributing

--- a/packages/maxim-max17048/usage.ato
+++ b/packages/maxim-max17048/usage.ato
@@ -3,7 +3,7 @@
 
 import ElectricPower
 import I2C
-from "maxim-max17048.ato" import Maxim_MAX17048
+from "atopile/maxim-max17048/maxim-max17048.ato" import Maxim_MAX17048
 
 module Battery:
     power = new ElectricPower

--- a/packages/memsic-mmc5603/README.md
+++ b/packages/memsic-mmc5603/README.md
@@ -22,7 +22,7 @@ The MMC5603 is a 3-axis anisotropic magnetoresistive (AMR) magnetic sensor from 
 import ElectricPower
 import I2C
 
-from "memsic-mmc5603.ato" import MEMSIC_MMC5603
+from "atopile/memsic-mmc5603/memsic-mmc5603.ato" import MEMSIC_MMC5603
 
 module Usage:
     """
@@ -44,6 +44,7 @@ module Usage:
     # Connect interfaces
     power_1v8 ~ magnetometer.power
     i2c_bus ~ magnetometer.i2c
+
 ```
 
 ## Technical Specifications

--- a/packages/memsic-mmc5603/usage.ato
+++ b/packages/memsic-mmc5603/usage.ato
@@ -4,7 +4,7 @@
 import ElectricPower
 import I2C
 
-from "memsic-mmc5603.ato" import MEMSIC_MMC5603
+from "atopile/memsic-mmc5603/memsic-mmc5603.ato" import MEMSIC_MMC5603
 
 module Usage:
     """

--- a/packages/microchip-cap1188/README.md
+++ b/packages/microchip-cap1188/README.md
@@ -24,7 +24,7 @@ import I2C
 import ElectricPower
 import ElectricLogic
 
-from "microchip-cap1188.ato" import Microchip_CAP1188
+from "atopile/microchip-cap1188/microchip-cap1188.ato" import Microchip_CAP1188
 
 module Usage:
     """
@@ -73,6 +73,7 @@ module Usage:
     # Connect some LEDs (as examples)
     status_led_1 ~ touch_sensor.led_outputs[0]
     status_led_2 ~ touch_sensor.led_outputs[1]
+
 ```
 
 ## Interfaces

--- a/packages/microchip-cap1188/usage.ato
+++ b/packages/microchip-cap1188/usage.ato
@@ -6,7 +6,7 @@ import I2C
 import ElectricPower
 import ElectricLogic
 
-from "microchip-cap1188.ato" import Microchip_CAP1188
+from "atopile/microchip-cap1188/microchip-cap1188.ato" import Microchip_CAP1188
 
 module Usage:
     """

--- a/packages/microchip-emc2101/README.md
+++ b/packages/microchip-emc2101/README.md
@@ -31,7 +31,7 @@ A comprehensive driver for the Microchip EMC2101 temperature monitoring and PWM 
 #pragma experiment("BRIDGE_CONNECT")
 
 import I2C, ElectricPower, ElectricLogic
-from "microchip-emc2101.ato" import Microchip_EMC2101
+from "atopile/microchip-emc2101/microchip-emc2101.ato" import Microchip_EMC2101
 
 module Usage:
     """
@@ -62,6 +62,7 @@ module Usage:
 
     # Connect fan PWM output
     fan_pwm_signal ~ temp_controller.pwm_out
+
 ```
 
 ### Optional Interfaces

--- a/packages/microchip-mcp23017/README.md
+++ b/packages/microchip-mcp23017/README.md
@@ -14,7 +14,8 @@ import ElectricPower
 import I2C
 
 # --- Package import ---
-from "microchip-mcp23017.ato" import Microchip_MCP23017
+from "atopile/microchip-mcp23017/microchip-mcp23017.ato" import Microchip_MCP23017
+
 
 module Usage:
     """
@@ -42,6 +43,7 @@ module Usage:
 
     # (Optional) Explicitly set the expander address – defaults to 0x20
     expander.i2c.address = 0x20
+
 ```
 
 ## Contributing

--- a/packages/microchip-mcp3421/README.md
+++ b/packages/microchip-mcp3421/README.md
@@ -13,7 +13,7 @@ The Microchip MCP3421 is an 18-bit, single-channel analog-to-digital converter w
 import ElectricPower
 import I2C
 
-from "microchip-mcp3421.ato" import Microchip_MCP3421
+from "atopile/microchip-mcp3421/microchip-mcp3421.ato" import Microchip_MCP3421
 
 module Usage:
     """
@@ -44,6 +44,7 @@ module Usage:
 
     # --- I2C address is fixed at 0x68 ---
     # No address configuration needed
+
 ```
 
 ## Features

--- a/packages/microchip-mcp3421/usage.ato
+++ b/packages/microchip-mcp3421/usage.ato
@@ -6,7 +6,7 @@
 import ElectricPower
 import I2C
 
-from "microchip-mcp3421.ato" import Microchip_MCP3421
+from "atopile/microchip-mcp3421/microchip-mcp3421.ato" import Microchip_MCP3421
 
 module Usage:
     """

--- a/packages/microchip-mcp4728/README.md
+++ b/packages/microchip-mcp4728/README.md
@@ -23,7 +23,7 @@ The MCP4728 is a quad channel, 12-bit voltage output Digital-to-Analog Converter
 import ElectricPower
 import I2C
 
-from "microchip-mcp4728.ato" import Microchip_MCP4728
+from "atopile/microchip-mcp4728/microchip-mcp4728.ato" import Microchip_MCP4728
 
 module Usage:
     """
@@ -58,6 +58,7 @@ module Usage:
     # dac.voutb.line - Channel B output
     # dac.voutc.line - Channel C output
     # dac.voutd.line - Channel D output
+
 ```
 
 ## I2C Address Configuration

--- a/packages/microchip-mcp4728/usage.ato
+++ b/packages/microchip-mcp4728/usage.ato
@@ -4,7 +4,7 @@
 import ElectricPower
 import I2C
 
-from "microchip-mcp4728.ato" import Microchip_MCP4728
+from "atopile/microchip-mcp4728/microchip-mcp4728.ato" import Microchip_MCP4728
 
 module Usage:
     """

--- a/packages/microchip-mcp9601/README.md
+++ b/packages/microchip-mcp9601/README.md
@@ -27,7 +27,7 @@ import I2C
 import ElectricPower
 import Resistor
 
-from "microchip-mcp9601.ato" import Microchip_MCP9601
+from "atopile/microchip-mcp9601/microchip-mcp9601.ato" import Microchip_MCP9601
 
 
 module Usage:
@@ -67,6 +67,7 @@ module Usage:
     # sensor.alert1, sensor.alert2, sensor.alert3, sensor.alert4
     # sensor.oc_alert (open-circuit detection)
     # sensor.sc_alert (short-circuit detection)
+
 ```
 
 ## Practical Implementation

--- a/packages/microchip-mcp9601/usage.ato
+++ b/packages/microchip-mcp9601/usage.ato
@@ -6,7 +6,7 @@ import I2C
 import ElectricPower
 import Resistor
 
-from "microchip-mcp9601.ato" import Microchip_MCP9601
+from "atopile/microchip-mcp9601/microchip-mcp9601.ato" import Microchip_MCP9601
 
 
 module Usage:

--- a/packages/microchip-mcp9808/README.md
+++ b/packages/microchip-mcp9808/README.md
@@ -22,7 +22,7 @@ High-precision digital temperature sensor with user-programmable temperature ale
 import I2C
 import ElectricPower
 
-from "microchip-mcp9808.ato" import Microchip_MCP9808
+from "atopile/microchip-mcp9808/microchip-mcp9808.ato" import Microchip_MCP9808
 
 
 module Usage:
@@ -48,6 +48,7 @@ module Usage:
     sensor.i2c.address = 0x1F
 
     # The alert output is available at sensor.alert if needed
+
 ```
 
 ## Pin Configuration

--- a/packages/microchip-mcp9808/usage.ato
+++ b/packages/microchip-mcp9808/usage.ato
@@ -5,7 +5,7 @@
 import I2C
 import ElectricPower
 
-from "microchip-mcp9808.ato" import Microchip_MCP9808
+from "atopile/microchip-mcp9808/microchip-mcp9808.ato" import Microchip_MCP9808
 
 
 module Usage:

--- a/packages/microphones/README.md
+++ b/packages/microphones/README.md
@@ -5,19 +5,51 @@ A collection of microphones with digital (PMD, I2S) and analog interfaces.
 ## Usage
 
 ```ato
-from "atopile/microphones/linkmems_lma3722t421_oa5.ato" import LinkMems_LMA3722T421_OA5
+import ElectricPower
+import I2S
+import ElectricSignal
+import PDM
 
-module LinkMems_LMA3722T421_OA5_example:
+from "atopile/microphones/knowles_sph0641lu4h_1.ato" import Knowles_SPH0641LU4H_1
+from "atopile/microphones/linkmems_lma3722t421_oa5.ato" import LinkMems_LMA3722T421_OA5
+from "atopile/microphones/linkmems_lmd2718t261_oa1.ato" import LinkMems_LMD2718T261_OA1
+from "atopile/microphones/tdk_invensense_ics_43434.ato" import TDK_InvenSense_ICS_43434
+from "atopile/microphones/tdk_mmict390200012.ato" import TDK_InvenSense_MMICT390200012
+
+module Usage:
     """
-    Minimal example of how to use the LinkMems LMA3722T421-OA5 analog microphone.
+    Minimal example of how to use the Knowles SPH0641LU4H I2S microphone.
     """
-    microphone = new LinkMems_LMA3722T421_OA5
+
+    microphone_i2s_1 = new Knowles_SPH0641LU4H_1
+    microphone_i2s_2 = new TDK_InvenSense_ICS_43434
+    microphone_analog_with_preamp = new LinkMems_LMA3722T421_OA5
+    microphone_pdm_1_8v = new LinkMems_LMD2718T261_OA1
+    microphone_pdm_3v3 = new TDK_InvenSense_MMICT390200012
 
     power_3v3 = new ElectricPower
-    power_3v3 ~ microphone.power
+    power_1v8 = new ElectricPower
+    power_3v3 ~ microphone_pdm_3v3.power
+    power_3v3 ~ microphone_i2s_2.power
+    power_3v3 ~ microphone_i2s_1.power
+    power_3v3 ~ microphone_analog_with_preamp.power
+    power_1v8 ~ microphone_pdm_1_8v.power
+
+    i2s = new I2S
+    i2s ~ microphone_i2s_1.i2s
+    i2s ~ microphone_i2s_2.i2s
 
     analog = new ElectricSignal
-    analog ~ microphone.analog
+    analog ~ microphone_analog_with_preamp.analog
+
+    pdm = new PDM
+    pdm ~ microphone_pdm_3v3.pdm
+    microphone_pdm_3v3.pdm.select.line ~ microphone_pdm_3v3.pdm.select.reference.hv # select L/R channel
+
+    pdm_1_8v = new PDM
+    pdm_1_8v ~ microphone_pdm_1_8v.pdm
+    microphone_pdm_1_8v.pdm.select.line ~ microphone_pdm_1_8v.pdm.select.reference.hv # select L/R channel
+
 ```
 
 ```ato

--- a/packages/mounting_holes/README.md
+++ b/packages/mounting_holes/README.md
@@ -23,7 +23,7 @@ Supported Pad Types:
 
 ```ato
 #pragma experiment("MODULE_TEMPLATING")
-from "atopile/mounting_holes/MountingHole.py" import MountingHole
+from "MountingHole.py" import MountingHole
 
 module Usage:
     """
@@ -38,6 +38,7 @@ module Usage:
     m2_with_pad.contact ~ m3_top_pad.contact
     m3_top_pad.contact ~ m4_pad_with_vias.contact
     # m6_no_pad has no contact
+
 ```
 
 ## Contributing

--- a/packages/netties/README.md
+++ b/packages/netties/README.md
@@ -34,7 +34,7 @@ The connect_gnd parameter can be used to connect the power.lv Electricals togeth
 #pragma experiment("BRIDGE_CONNECT")
 import ElectricPower
 
-from "atopile/netties/NetTie.py" import NetTie
+from "NetTie.py" import NetTie
 
 module Usage:
     """
@@ -63,6 +63,7 @@ module Usage:
     # connect power.hv's together
     power_a ~> basic_nettie_hv_connect ~> power_b
     power_a ~> basic_thru_hole_nettie_hv_connect ~> power_b
+
 ```
 
 ## Contributing

--- a/packages/nxp-pcf8574/README.md
+++ b/packages/nxp-pcf8574/README.md
@@ -19,7 +19,7 @@ A comprehensive driver for the NXP PCF8574 remote 8-bit I/O expander for I2C-bus
 #pragma experiment("FOR_LOOP")
 
 import I2C, ElectricPower, ElectricLogic
-from "nxp-pcf8574.ato" import NXP_PCF8574
+from "atopile/nxp-pcf8574/nxp-pcf8574.ato" import NXP_PCF8574
 
 module Usage:
     """
@@ -67,6 +67,7 @@ module Usage:
     button_inputs[1] ~ gpio_expander.gpio[5]
     button_inputs[2] ~ gpio_expander.gpio[6]
     button_inputs[3] ~ gpio_expander.gpio[7]
+
 ```
 
 ## Key Interfaces

--- a/packages/nxp-pcf8575/README.md
+++ b/packages/nxp-pcf8575/README.md
@@ -20,7 +20,7 @@ A comprehensive driver for the NXP PCF8575 remote 16-bit I/O expander for I2C-bu
 #pragma experiment("FOR_LOOP")
 
 import I2C, ElectricPower, ElectricLogic
-from "nxp-pcf8575.ato" import NXP_PCF8575
+from "atopile/nxp-pcf8575/nxp-pcf8575.ato" import NXP_PCF8575
 
 module Usage:
     """
@@ -76,6 +76,7 @@ module Usage:
     button_inputs[5] ~ gpio_expander.gpio[13]
     button_inputs[6] ~ gpio_expander.gpio[14]
     button_inputs[7] ~ gpio_expander.gpio[15]
+
 ```
 
 ## Key Interfaces

--- a/packages/nxp-pct2075/README.md
+++ b/packages/nxp-pct2075/README.md
@@ -22,7 +22,7 @@ Driver for the NXP PCT2075 I²C temperature sensor and thermal watchdog. This di
 import ElectricPower
 import I2C
 
-from "nxp-pct2075.ato" import NXP_PCT2075
+from "atopile/nxp-pct2075/nxp-pct2075.ato" import NXP_PCT2075
 
 module Usage:
     """
@@ -44,6 +44,7 @@ module Usage:
 
     # Set I²C address (default 0x48 with all address pins low)
     sensor.i2c.address = 0x48
+
 ```
 
 ## I²C Address Configuration

--- a/packages/nxp-pct2075/usage.ato
+++ b/packages/nxp-pct2075/usage.ato
@@ -5,7 +5,7 @@
 import ElectricPower
 import I2C
 
-from "nxp-pct2075.ato" import NXP_PCT2075
+from "atopile/nxp-pct2075/nxp-pct2075.ato" import NXP_PCT2075
 
 module Usage:
     """

--- a/packages/nxp-pn5321/README.md
+++ b/packages/nxp-pn5321/README.md
@@ -5,39 +5,27 @@
 ```ato
 import ElectricPower
 import DifferentialPair
-import Resistor
+import I2C
 
 from "atopile/nxp-pn5321/nxp-pn5321.ato" import NXP_PN5321_driver
-from "atopile/esp32/esp32_c3.ato" import ESP32_C3_WROOM
 
 module Antenna:
     input = new DifferentialPair
 
-module Example:
-    esp32 = new ESP32_C3_WROOM
+module Usage:
     nfc = new NXP_PN5321_driver
     antenna = new Antenna
 
     # Power
     power_3v3 = new ElectricPower
-    power_3v3.voltage = 3.3V
-    power_3v3 ~ esp32.power
+    power_3v3.voltage = 3.3V +/- 10%
     power_3v3 ~ nfc.power_3v3
 
-    # I2C pullups
-    pullups = new Resistor[2]
-    for pullup in pullups:
-        pullup.package = "R0402"
-        pullup.resistance = 4.7kohm +/- 10%
+    # I2C interface
+    i2c = new I2C
+    i2c ~ nfc.i2c
 
-    esp32.i2c[0].sda.line ~> pullups[0] ~> power_3v3.vcc
-    esp32.i2c[0].scl.line ~> pullups[1] ~> power_3v3.vcc
-
-    # Connect comms to nfc
-    esp32.i2c[0] ~ nfc.i2c
-    esp32.gpios[10] ~ nfc.reset
-    esp32.gpios[11] ~ nfc.interrupt
-
+    # Antenna connection
     nfc.antenna_output ~ antenna.input
 
 ```

--- a/packages/nxp-pn5321/usage.ato
+++ b/packages/nxp-pn5321/usage.ato
@@ -2,7 +2,7 @@ import ElectricPower
 import DifferentialPair
 import I2C
 
-from "nxp-pn5321.ato" import NXP_PN5321_driver
+from "atopile/nxp-pn5321/nxp-pn5321.ato" import NXP_PN5321_driver
 
 module Antenna:
     input = new DifferentialPair

--- a/packages/opsco-sk6805-ec15/README.md
+++ b/packages/opsco-sk6805-ec15/README.md
@@ -24,7 +24,7 @@ The SK6805-EC15 is the smallest member of the SK6805 addressable LED family, fea
 import ElectricPower
 import ElectricLogic
 
-from "opsco-sk6805-ec15.ato" import OPSCO_SK6805_EC15
+from "atopile/opsco-sk6805-ec15/opsco-sk6805-ec15.ato" import OPSCO_SK6805_EC15
 
 module Usage:
     """
@@ -51,6 +51,7 @@ module Usage:
 
     # Chain LEDs in matrix order for high-density display
     data_input ~> led_matrix[0] ~> led_matrix[1] ~> led_matrix[2] ~> led_matrix[3] ~> led_matrix[4] ~> led_matrix[5] ~> led_matrix[6] ~> led_matrix[7] ~> led_matrix[8] ~> led_matrix[9] ~> led_matrix[10] ~> led_matrix[11] ~> led_matrix[12] ~> led_matrix[13] ~> led_matrix[14] ~> led_matrix[15]
+
 ```
 
 ## Technical Specifications

--- a/packages/opsco-sk6805-ec15/usage.ato
+++ b/packages/opsco-sk6805-ec15/usage.ato
@@ -5,7 +5,7 @@
 import ElectricPower
 import ElectricLogic
 
-from "opsco-sk6805-ec15.ato" import OPSCO_SK6805_EC15
+from "atopile/opsco-sk6805-ec15/opsco-sk6805-ec15.ato" import OPSCO_SK6805_EC15
 
 module Usage:
     """

--- a/packages/opsco-sk6805-ec20/README.md
+++ b/packages/opsco-sk6805-ec20/README.md
@@ -23,7 +23,7 @@ The SK6805-EC20 is a compact 2x2mm addressable RGB LED with integrated controlle
 import ElectricPower
 import ElectricLogic
 
-from "opsco-sk6805-ec20.ato" import OPSCO_SK6805_EC20
+from "atopile/opsco-sk6805-ec20/opsco-sk6805-ec20.ato" import OPSCO_SK6805_EC20
 
 module Usage:
     """
@@ -50,6 +50,7 @@ module Usage:
 
     # Chain LEDs together: data flows through each LED
     data_input ~> leds[0] ~> leds[1] ~> leds[2] ~> leds[3] ~> leds[4] ~> leds[5] ~> leds[6] ~> leds[7] ~> leds[8] ~> leds[9]
+
 ```
 
 ## Technical Specifications

--- a/packages/opsco-sk6805-ec20/usage.ato
+++ b/packages/opsco-sk6805-ec20/usage.ato
@@ -5,7 +5,7 @@
 import ElectricPower
 import ElectricLogic
 
-from "opsco-sk6805-ec20.ato" import OPSCO_SK6805_EC20
+from "atopile/opsco-sk6805-ec20/opsco-sk6805-ec20.ato" import OPSCO_SK6805_EC20
 
 module Usage:
     """

--- a/packages/opsco-sk6805-side/README.md
+++ b/packages/opsco-sk6805-side/README.md
@@ -24,7 +24,7 @@ The SK6805-SIDE is a side-emitting addressable RGB LED with integrated controlle
 import ElectricPower
 import ElectricLogic
 
-from "opsco-sk6805-side.ato" import OPSCO_SK6805_SIDE
+from "atopile/opsco-sk6805-side/opsco-sk6805-side.ato" import OPSCO_SK6805_SIDE
 
 module Usage:
     """
@@ -51,6 +51,7 @@ module Usage:
 
     # Chain LEDs together for edge lighting effect
     data_input ~> edge_leds[0] ~> edge_leds[1] ~> edge_leds[2] ~> edge_leds[3] ~> edge_leds[4] ~> edge_leds[5] ~> edge_leds[6] ~> edge_leds[7]
+
 ```
 
 ## Technical Specifications

--- a/packages/opsco-sk6805-side/usage.ato
+++ b/packages/opsco-sk6805-side/usage.ato
@@ -5,7 +5,7 @@
 import ElectricPower
 import ElectricLogic
 
-from "opsco-sk6805-side.ato" import OPSCO_SK6805_SIDE
+from "atopile/opsco-sk6805-side/opsco-sk6805-side.ato" import OPSCO_SK6805_SIDE
 
 module Usage:
     """

--- a/packages/pjrc-teensy_4_1/README.md
+++ b/packages/pjrc-teensy_4_1/README.md
@@ -25,8 +25,16 @@ The PJRC Teensy 4.1 is a microcontroller board based on the NXP MCU LPC5526.
 ## Usage
 
 ```ato
+#pragma experiment("BRIDGE_CONNECT")
+import Ethernet
+import Capacitor
+
 from "atopile/pjrc-teensy_4_1/pjrc-teensy_4_1.ato" import PJRC_Teensy_4_1
+
+from "parts/WIZNET_J1B1211CCD/WIZNET_J1B1211CCD.ato" import WIZNET_J1B1211CCD_package
+
 from "atopile/usb-connectors/usb-connectors.ato" import USBCConn
+from "atopile/buttons/buttons.ato" import VerticalButton
 
 module Usage:
     """
@@ -36,18 +44,56 @@ module Usage:
     teensy = new PJRC_Teensy_4_1
     usb_connector = new USBCConn
     ethernet_connector = new EthernetConnector
+    power_button = new VerticalButton
+    program_button = new VerticalButton
 
     # --- Connections ---
     teensy.usb_device ~ usb_connector.usb2
     teensy.ethernet ~ ethernet_connector.ethernet
 
-    # --- Net renaming (optional) ---
+    teensy.on_off.line ~> power_button ~> teensy.on_off.reference.lv
+    teensy.program.line ~> program_button ~> teensy.program.reference.lv
+
+    # --- Net renaming ---
     teensy.usb_device.usb_if.d.p.line.override_net_name = "USB_P"
     teensy.usb_device.usb_if.d.n.line.override_net_name = "USB_N"
+    teensy.usb_host.usb_if.d.p.line.override_net_name = "USB_HOST_P"
+    teensy.usb_host.usb_if.d.n.line.override_net_name = "USB_HOST_N"
     teensy.ethernet.pairs[0].p.line.override_net_name = "ETH_RX_P"
     teensy.ethernet.pairs[0].n.line.override_net_name = "ETH_RX_N"
     teensy.ethernet.pairs[1].p.line.override_net_name = "ETH_TX_P"
     teensy.ethernet.pairs[1].n.line.override_net_name = "ETH_TX_N"
+
+module EthernetConnector:
+    """
+    RJ45 connector with Ethernet interface
+    """
+    # --- Components ---
+    connector = new WIZNET_J1B1211CCD_package
+    capacitor = new Capacitor
+    assert capacitor.capacitance within 100nF +/- 10%
+    capacitor.package = "0402"
+
+    # --- External interfaces ---
+    ethernet = new Ethernet
+
+    # --- internal connections ---
+    connector.9 ~ connector.8
+    connector.8 ~> capacitor ~> connector.2
+    connector.8 ~> capacitor ~> connector.5
+
+    # --- package connections ---
+    ethernet.pairs[0].n.line ~ connector.6
+    ethernet.pairs[0].p.line ~ connector.4
+    ethernet.pairs[1].n.line ~ connector.3
+    ethernet.pairs[1].p.line ~ connector.1
+
+    ethernet.led_speed.line ~ connector.10 # LLEDpos
+    ethernet.led_speed.reference.lv ~ connector.9 # LLEDneg
+
+    ethernet.led_speed.reference.lv ~ connector.14 # GND
+    ethernet.led_speed.reference.lv ~ connector.13 # GND
+
 ```
 
 ## Contributing

--- a/packages/pjrc-teensy_4_1/usage.ato
+++ b/packages/pjrc-teensy_4_1/usage.ato
@@ -2,7 +2,7 @@
 import Ethernet
 import Capacitor
 
-from "pjrc-teensy_4_1.ato" import PJRC_Teensy_4_1
+from "atopile/pjrc-teensy_4_1/pjrc-teensy_4_1.ato" import PJRC_Teensy_4_1
 
 from "parts/WIZNET_J1B1211CCD/WIZNET_J1B1211CCD.ato" import WIZNET_J1B1211CCD_package
 

--- a/packages/raspberry-rp2040/README.md
+++ b/packages/raspberry-rp2040/README.md
@@ -18,7 +18,7 @@ import Resistor
 import LDO
 
 from "atopile/raspberry-rp2040/raspberry-rp2040.ato" import Raspberry_Pi_RP2040
-from "atopile/st-ldk220/ldk220.ato" import LDK220M_R
+from "atopile/st-ldk220/st-ldk220.ato" import LDK220M_R
 
 from "parts/SHOU_HAN_TYPE_C_16PIN_2MD_073/SHOU_HAN_TYPE_C_16PIN_2MD_073.ato" import SHOU_HAN_TYPE_C_16PIN_2MD_073_package
 
@@ -69,6 +69,7 @@ module Usage:
 
     # I²C connection
     mcu.i2c ~ sensor.i2c
+
 ```
 
 ## Contributing

--- a/packages/rohm-bh1750/README.md
+++ b/packages/rohm-bh1750/README.md
@@ -18,7 +18,7 @@ The BH1750 is a digital ambient light sensor with I²C interface that provides a
 import ElectricPower
 import I2C
 
-from "rohm-bh1750.ato" import ROHM_BH1750
+from "atopile/rohm-bh1750/rohm-bh1750.ato" import ROHM_BH1750
 
 module MCU:
     """Host MCU providing I²C bus and power rail."""
@@ -42,6 +42,7 @@ module Usage:
 
     # I²C connection
     mcu.i2c ~ lux_sensor.i2c
+
 ```
 
 ## Interface Details

--- a/packages/rohm-bh1750/usage.ato
+++ b/packages/rohm-bh1750/usage.ato
@@ -1,7 +1,7 @@
 import ElectricPower
 import I2C
 
-from "rohm-bh1750.ato" import ROHM_BH1750
+from "atopile/rohm-bh1750/rohm-bh1750.ato" import ROHM_BH1750
 
 module MCU:
     """Host MCU providing I²C bus and power rail."""

--- a/packages/saleae-header/README.md
+++ b/packages/saleae-header/README.md
@@ -44,6 +44,7 @@ module Usage:
     example_signals[1] ~ harness_saleae_debug_header.channels[1]
     example_signals[2] ~ harness_saleae_debug_header.channels[2]
     example_signals[3] ~ harness_saleae_debug_header.channels[3]
+
 ```
 
 ## Contributing

--- a/packages/sensirion-scd40/README.md
+++ b/packages/sensirion-scd40/README.md
@@ -18,28 +18,22 @@ import I2C
 
 from "atopile/sensirion-scd40/sensirion-scd40.ato" import Sensirion_SCD40
 
-module MCU:
-    """Host MCU providing I²C bus and power rail."""
-
-    power = new ElectricPower
-    i2c = new I2C
-
-
 module Usage:
     """Minimal example for the Sensirion_SCD40 CO₂ sensor."""
 
     # MCU & sensor
-    mcu = new MCU
+    power = new ElectricPower
+    i2c = new I2C
+
     co2_sensor = new Sensirion_SCD40
 
     # Shared 3V3 rail
-    power = new ElectricPower
-    power.voltage = 3.3V
-    power ~ mcu.power
+    power.voltage = 3.3V +/- 5%
+    power ~ power
     power ~ co2_sensor.power
 
     # I²C connection
-    mcu.i2c ~ co2_sensor.i2c
+    i2c ~ co2_sensor.i2c
 
 ```
 

--- a/packages/sensirion-scd40/README.md
+++ b/packages/sensirion-scd40/README.md
@@ -40,6 +40,7 @@ module Usage:
 
     # I²C connection
     mcu.i2c ~ co2_sensor.i2c
+
 ```
 
 ## Contributing

--- a/packages/sensirion-scd40/ato.yaml
+++ b/packages/sensirion-scd40/ato.yaml
@@ -18,7 +18,7 @@ package:
   identifier: atopile/sensirion-scd40
   repository: https://github.com/atopile/packages
   homepage: https://github.com/atopile/packages/blob/main/packages/sensirion-scd40/README.md
-  version: "0.1.0"
+  version: "0.1.1"
   authors:
     - name: atopile
       email: hi@atopile.io

--- a/packages/sensirion-scd40/usage.ato
+++ b/packages/sensirion-scd40/usage.ato
@@ -3,25 +3,19 @@ import I2C
 
 from "atopile/sensirion-scd40/sensirion-scd40.ato" import Sensirion_SCD40
 
-module MCU:
-    """Host MCU providing I²C bus and power rail."""
-
-    power = new ElectricPower
-    i2c = new I2C
-
-
 module Usage:
     """Minimal example for the Sensirion_SCD40 CO₂ sensor."""
 
     # MCU & sensor
-    mcu = new MCU
+    power = new ElectricPower
+    i2c = new I2C
+
     co2_sensor = new Sensirion_SCD40
 
     # Shared 3V3 rail
-    power = new ElectricPower
-    power.voltage = 3.3V
-    power ~ mcu.power
+    power.voltage = 3.3V +/- 5%
+    power ~ power
     power ~ co2_sensor.power
 
     # I²C connection
-    mcu.i2c ~ co2_sensor.i2c
+    i2c ~ co2_sensor.i2c

--- a/packages/sensirion-scd41/README.md
+++ b/packages/sensirion-scd41/README.md
@@ -48,14 +48,15 @@ The SCD41 has separate power domains:
 ## Usage
 
 ```ato
-#pragma text
+#pragma experiment("MODULE_TEMPLATING")
 #pragma experiment("BRIDGE_CONNECT")
+#pragma experiment("FOR_LOOP")
 
 import ElectricPower
 import I2C
 import Resistor
 
-from "sensirion-scd41.ato" import Sensirion_SCD41
+from "atopile/sensirion-scd41/sensirion-scd41.ato" import Sensirion_SCD41
 
 module Usage:
     """
@@ -79,20 +80,15 @@ module Usage:
     power_3v3 ~ co2_sensor.power_heater
     i2c_bus ~ co2_sensor.i2c
 
+    # --- Provide I2C bus reference voltage ---
+    power_3v3 ~ i2c_bus.scl.reference
+    power_3v3 ~ i2c_bus.sda.reference
+
     # --- I2C address is fixed at 0x62 ---
-    # No address configuration needed for SCD41
+    co2_sensor.i2c.address = 0x62
 
-    # --- Optional: I2C pull-up resistors ---
-    # Many development boards already include these
-    i2c_pullup_scl = new Resistor
-    i2c_pullup_sda = new Resistor
-    i2c_pullup_scl.resistance = 4.7kohm +/- 5%
-    i2c_pullup_sda.resistance = 4.7kohm +/- 5%
-    i2c_pullup_scl.package = "0402"
-    i2c_pullup_sda.package = "0402"
-
-    power_3v3.hv ~> i2c_pullup_scl ~> i2c_bus.scl.line
-    power_3v3.hv ~> i2c_pullup_sda ~> i2c_bus.sda.line
+    # --- I2C pull-up resistors are included in the sensor module ---
+    # No external pullup resistors needed
 
     # --- Usage notes ---
     # The SCD41 measures:
@@ -105,6 +101,7 @@ module Usage:
     # - Single-shot measurement mode for low power
     # - Automatic baseline correction
     # - No need for external calibration in most applications
+
 ```
 
 ## Operation Modes

--- a/packages/sensirion-scd41/usage.ato
+++ b/packages/sensirion-scd41/usage.ato
@@ -6,7 +6,7 @@ import ElectricPower
 import I2C
 import Resistor
 
-from "sensirion-scd41.ato" import Sensirion_SCD41
+from "atopile/sensirion-scd41/sensirion-scd41.ato" import Sensirion_SCD41
 
 module Usage:
     """

--- a/packages/sensirion-sen6x/README.md
+++ b/packages/sensirion-sen6x/README.md
@@ -36,6 +36,7 @@ module Usage:
 
     # I²C connection
     mcu.i2c ~ environment_sensor.i2c
+
 ```
 
 ## Contributing

--- a/packages/sensirion-sgp40/README.md
+++ b/packages/sensirion-sgp40/README.md
@@ -24,7 +24,7 @@ A comprehensive atopile package for the Sensirion SGP40 digital VOC (Volatile Or
 import ElectricPower
 import I2C
 
-from "sensirion-sgp40.ato" import Sensirion_SGP40
+from "atopile/sensirion-sgp40/sensirion-sgp40.ato" import Sensirion_SGP40
 
 module Usage:
     """
@@ -38,7 +38,7 @@ module Usage:
 
     # I2C bus
     i2c_bus = new I2C
-    i2c_bus.frequency = 400000Hz  # Fast mode I2C
+    i2c_bus.frequency = 400kHz  # Fast mode I2C
 
     # VOC gas sensor instance
     voc_sensor = new Sensirion_SGP40
@@ -52,6 +52,7 @@ module Usage:
 
     # The SGP40 has a fixed I2C address of 0x59
     assert voc_sensor.i2c.address is 0x59
+
 ```
 
 ## Hardware Features

--- a/packages/sensirion-sgp40/usage.ato
+++ b/packages/sensirion-sgp40/usage.ato
@@ -5,7 +5,7 @@
 import ElectricPower
 import I2C
 
-from "sensirion-sgp40.ato" import Sensirion_SGP40
+from "atopile/sensirion-sgp40/sensirion-sgp40.ato" import Sensirion_SGP40
 
 module Usage:
     """

--- a/packages/sensirion-sht31/README.md
+++ b/packages/sensirion-sht31/README.md
@@ -14,13 +14,14 @@ import ElectricPower
 import I2C
 
 # --- Package import ---
-from "sensirion-sht31.ato" import Sensirion_SHT31
+from "atopile/sensirion-sht31/sensirion-sht31.ato" import Sensirion_SHT31
+
 
 module Usage:
     """
     Minimal usage example for `sensirion-sht31`.
     Powers the SHT31 from a 3 V 3 rail and connects it to an I²C bus using the
-    default address (0x44).
+    default address **0x44** (ADDR pin low).
     """
 
     # Power rail (3.3 V)
@@ -45,6 +46,7 @@ module Usage:
 
     # (Optional) Select address – defaults to 0x44 (ADDR=0)
     sensor.i2c.address = 0x44
+
 ```
 
 ## Contributing

--- a/packages/sensirion-sht31/usage.ato
+++ b/packages/sensirion-sht31/usage.ato
@@ -7,7 +7,7 @@ import ElectricPower
 import I2C
 
 # --- Package import ---
-from "sensirion-sht31.ato" import Sensirion_SHT31
+from "atopile/sensirion-sht31/sensirion-sht31.ato" import Sensirion_SHT31
 
 
 module Usage:

--- a/packages/sensirion-sht40/README.md
+++ b/packages/sensirion-sht40/README.md
@@ -24,7 +24,7 @@ import ElectricPower
 import I2C
 
 # --- Package import ---
-from "sensirion-sht40.ato" import SHT40_driver
+from "atopile/sensirion-sht40/sensirion-sht40.ato" import Sensirion_SHT40
 
 
 module Usage:
@@ -36,13 +36,13 @@ module Usage:
 
     # Power rail (3.3 V)
     power_3v3 = new ElectricPower
-    power_3v3.voltage = 3.3V
+    assert power_3v3.voltage within 3.2V to 3.4V
 
     # I²C bus
     i2c_bus = new I2C
 
     # Sensor instance
-    sensor = new SHT40_driver
+    sensor = new Sensirion_SHT40
 
     # Connect required power rail
     power_3v3 ~ sensor.power
@@ -56,6 +56,7 @@ module Usage:
 
     # Address is fixed at 0x44 (no configuration needed)
     sensor.i2c.address = 0x44
+
 ```
 
 ## Interface Details

--- a/packages/sensirion-sht40/usage.ato
+++ b/packages/sensirion-sht40/usage.ato
@@ -7,7 +7,7 @@ import ElectricPower
 import I2C
 
 # --- Package import ---
-from "sensirion-sht40.ato" import Sensirion_SHT40
+from "atopile/sensirion-sht40/sensirion-sht40.ato" import Sensirion_SHT40
 
 
 module Usage:

--- a/packages/sensirion-sht41/README.md
+++ b/packages/sensirion-sht41/README.md
@@ -25,7 +25,7 @@ A comprehensive atopile package for the Sensirion SHT41 cost-effective digital t
 import ElectricPower
 import I2C
 
-from "sensirion-sht41.ato" import Sensirion_SHT41
+from "atopile/sensirion-sht41/sensirion-sht41.ato" import Sensirion_SHT41
 
 module Usage:
     """
@@ -52,6 +52,7 @@ module Usage:
 
     # The SHT41A-FD1B has a default I2C address of 0x44
     assert temp_humidity_sensor.i2c.address is 0x44
+
 ```
 
 ## Hardware Features

--- a/packages/sensirion-sht41/usage.ato
+++ b/packages/sensirion-sht41/usage.ato
@@ -5,7 +5,7 @@
 import ElectricPower
 import I2C
 
-from "sensirion-sht41.ato" import Sensirion_SHT41
+from "atopile/sensirion-sht41/sensirion-sht41.ato" import Sensirion_SHT41
 
 module Usage:
     """

--- a/packages/sensirion-sht45/README.md
+++ b/packages/sensirion-sht45/README.md
@@ -24,7 +24,7 @@ A comprehensive atopile package for the Sensirion SHT45 high-accuracy digital te
 import ElectricPower
 import I2C
 
-from "sensirion-sht45.ato" import Sensirion_SHT45
+from "atopile/sensirion-sht45/sensirion-sht45.ato" import Sensirion_SHT45
 
 module Usage:
     """
@@ -51,6 +51,7 @@ module Usage:
 
     # The SHT45-AD1F has a default I2C address of 0x44
     assert temp_humidity_sensor.i2c.address is 0x44
+
 ```
 
 ## Hardware Features

--- a/packages/sensirion-sht45/usage.ato
+++ b/packages/sensirion-sht45/usage.ato
@@ -5,7 +5,7 @@
 import ElectricPower
 import I2C
 
-from "sensirion-sht45.ato" import Sensirion_SHT45
+from "atopile/sensirion-sht45/sensirion-sht45.ato" import Sensirion_SHT45
 
 module Usage:
     """

--- a/packages/sparkfun-qwiic/README.md
+++ b/packages/sparkfun-qwiic/README.md
@@ -58,6 +58,7 @@ module Usage:
         resistor.package = "0402"
     i2c.scl.line ~> pullup_resistors[0] ~> i2c.scl.reference.hv
     i2c.sda.line ~> pullup_resistors[1] ~> i2c.sda.reference.hv
+
 ```
 
 ## Contributing

--- a/packages/st-hts221/README.md
+++ b/packages/st-hts221/README.md
@@ -22,10 +22,12 @@ The STMicroelectronics HTS221 is a compact digital humidity and temperature sens
 #pragma experiment("TRAITS")
 #pragma experiment("MODULE_TEMPLATING")
 
-from "atopile/interfacing/i2c.ato" import I2C
-from "atopile/power/power.ato" import Power
+import I2C
+import ElectricPower
+import ElectricLogic
+import Resistor
 
-from "st-hts221.ato" import ST_HTS221
+from "atopile/st-hts221/st-hts221.ato" import ST_HTS221
 
 module Usage:
     """
@@ -36,7 +38,7 @@ module Usage:
     sensor = new ST_HTS221
 
     # Connect power supply
-    power_3v3 = new Power
+    power_3v3 = new ElectricPower
     power_3v3.voltage = 3.3V +/- 5%
     power_3v3 ~ sensor.power
 
@@ -44,6 +46,14 @@ module Usage:
     i2c_bus = new I2C
     i2c_bus.frequency = 400kHz
     i2c_bus ~ sensor.i2c
+
+    # Set CS high for I2C mode
+    cs_pullup = new Resistor
+    cs_pullup.resistance = 10kohm +/- 1%
+    cs_pullup.package = "0402"
+    power_3v3.hv ~> cs_pullup ~> sensor.cs.line
+    power_3v3 ~ sensor.power
+
 ```
 
 ## Contributing

--- a/packages/st-hts221/usage.ato
+++ b/packages/st-hts221/usage.ato
@@ -8,7 +8,7 @@ import ElectricPower
 import ElectricLogic
 import Resistor
 
-from "st-hts221.ato" import ST_HTS221
+from "atopile/st-hts221/st-hts221.ato" import ST_HTS221
 
 module Usage:
     """

--- a/packages/st-ism330dhcx/README.md
+++ b/packages/st-ism330dhcx/README.md
@@ -25,7 +25,7 @@ import ElectricPower
 import I2C
 import ElectricLogic
 
-from "st-ism330dhcx.ato" import ST_ISM330DHCX
+from "atopile/st-ism330dhcx/st-ism330dhcx.ato" import ST_ISM330DHCX
 
 module Usage:
     """
@@ -57,6 +57,11 @@ module Usage:
 
     # Set I²C address to 0x6A (SA0 pulled low)
     assert sensor.i2c.address is 0x6A
+
+    # Optional: Connect external sensor via auxiliary SPI
+    # external_magnetometer_cs = new ElectricLogic
+    # external_magnetometer_cs ~ sensor.aux_spi_cs
+
 ```
 
 ## Applications

--- a/packages/st-ism330dhcx/usage.ato
+++ b/packages/st-ism330dhcx/usage.ato
@@ -6,7 +6,7 @@ import ElectricPower
 import I2C
 import ElectricLogic
 
-from "st-ism330dhcx.ato" import ST_ISM330DHCX
+from "atopile/st-ism330dhcx/st-ism330dhcx.ato" import ST_ISM330DHCX
 
 module Usage:
     """

--- a/packages/st-ldk220/README.md
+++ b/packages/st-ldk220/README.md
@@ -22,22 +22,26 @@ import ElectricPower
 
 from "atopile/st-ldk220/st-ldk220.ato" import LDK220M_R
 
+module MCU:
+    """Host MCU providing power rail."""
+
+    power = new ElectricPower
+    assert power.voltage is 3.3V +/- 5%
+
+
 module Usage:
-    """Example using LDK220M-R to generate 3.3V from 5V input."""
+    """Minimal example for the LDK220M-R LDO."""
 
-    # Define input power
-    power_5v = new ElectricPower
-    assert power_5v.voltage is 5V +/- 5%
+    some_input_power = new ElectricPower
+    assert some_input_power.voltage is 5V +/- 5%
 
-    # Define output power requirement
-    power_3v3 = new ElectricPower
-    assert power_3v3.voltage is 3.3V +/- 5%
-
-    # Create LDO instance
+    # MCU & sensor
+    mcu = new MCU
     ldo = new LDK220M_R
 
-    # Connect power rails
-    power_5v ~> ldo ~> power_3v3
+    # Shared 3V3 rail
+    some_input_power ~> ldo ~> mcu.power
+
 ```
 
 ## Output Voltage Configuration

--- a/packages/st-lis2mdl/README.md
+++ b/packages/st-lis2mdl/README.md
@@ -42,6 +42,7 @@ module Usage:
 
     # Set I2C address
     assert magnetometer.i2c.address is 0x1E
+
 ```
 
 ## Contributing

--- a/packages/st-lis331/README.md
+++ b/packages/st-lis331/README.md
@@ -18,7 +18,7 @@ The LIS331DLH is a high-performance triple-axis digital accelerometer with selec
 import I2C
 import ElectricPower
 
-from "st-lis331.ato" import ST_LIS331
+from "atopile/st-lis331/st-lis331.ato" import ST_LIS331
 
 module Usage:
     """
@@ -46,6 +46,7 @@ module Usage:
 
     # Connect I2C
     i2c_bus ~ accelerometer.i2c
+
 ```
 
 ## Contributing

--- a/packages/st-lis331/usage.ato
+++ b/packages/st-lis331/usage.ato
@@ -1,7 +1,7 @@
 import I2C
 import ElectricPower
 
-from "st-lis331.ato" import ST_LIS331
+from "atopile/st-lis331/st-lis331.ato" import ST_LIS331
 
 module Usage:
     """

--- a/packages/st-lis3dh/README.md
+++ b/packages/st-lis3dh/README.md
@@ -24,7 +24,7 @@ import ElectricPower
 import I2C
 import ElectricLogic
 
-from "st-lis3dh.ato" import ST_LIS3DH
+from "atopile/st-lis3dh/st-lis3dh.ato" import ST_LIS3DH
 
 module Usage:
     """
@@ -56,6 +56,11 @@ module Usage:
 
     # Set I²C address to 0x18 (SA0 pulled low)
     assert sensor.i2c.address is 0x18
+
+    # Optional: Connect auxiliary ADC inputs if needed
+    # external_signal1 = new ElectricLogic
+    # external_signal1 ~ sensor.adc1
+
 ```
 
 ## Applications

--- a/packages/st-lis3dh/usage.ato
+++ b/packages/st-lis3dh/usage.ato
@@ -6,7 +6,7 @@ import ElectricPower
 import I2C
 import ElectricLogic
 
-from "st-lis3dh.ato" import ST_LIS3DH
+from "atopile/st-lis3dh/st-lis3dh.ato" import ST_LIS3DH
 
 module Usage:
     """

--- a/packages/st-lis3mdl/README.md
+++ b/packages/st-lis3mdl/README.md
@@ -11,7 +11,7 @@ This package provides an ato driver that models the device for use in Atopile pr
 
 import ElectricPower
 import I2C
-from "st-lis3mdl.ato" import ST_LIS3MDL
+from "atopile/st-lis3mdl/st-lis3mdl.ato" import ST_LIS3MDL
 
 module Usage:
     """Minimal usage example for `st-lis3mdl`.
@@ -33,6 +33,7 @@ module Usage:
     # Configure I²C address (SA1 pulled low => 0x1C)
     # SA1 pulled high => 0x1E
     assert i2c_bus.address is 0x1C
+
 ```
 
 ## PCB footprints & symbol

--- a/packages/st-lis3mdl/usage.ato
+++ b/packages/st-lis3mdl/usage.ato
@@ -2,7 +2,7 @@
 
 import ElectricPower
 import I2C
-from "st-lis3mdl.ato" import ST_LIS3MDL
+from "atopile/st-lis3mdl/st-lis3mdl.ato" import ST_LIS3MDL
 
 module Usage:
     """Minimal usage example for `st-lis3mdl`.

--- a/packages/st-lps22/README.md
+++ b/packages/st-lps22/README.md
@@ -24,7 +24,7 @@ The LPS22 is an ultra-compact MEMS nano pressure sensor featuring high accuracy 
 import ElectricPower
 import I2C
 
-from "st-lps22.ato" import ST_LPS22
+from "atopile/st-lps22/st-lps22.ato" import ST_LPS22
 
 module Usage:
     """
@@ -43,7 +43,7 @@ module Usage:
 
     # Power supply (3.3V rail)
     power_3v3 = new ElectricPower
-    power_3v3.voltage = 3.3V +/- 5%
+    assert power_3v3.voltage within 3.2V to 3.4V
 
     # Connect power supply
     power_3v3 ~ sensor.power
@@ -54,6 +54,7 @@ module Usage:
 
     # Configure I²C address to 0x5C (SA0 pin will be pulled low)
     sensor.i2c.address = 0x5C
+
 ```
 
 ## Interface Details

--- a/packages/st-lps22/usage.ato
+++ b/packages/st-lps22/usage.ato
@@ -5,7 +5,7 @@
 import ElectricPower
 import I2C
 
-from "st-lps22.ato" import ST_LPS22
+from "atopile/st-lps22/st-lps22.ato" import ST_LPS22
 
 module Usage:
     """

--- a/packages/st-lps28/README.md
+++ b/packages/st-lps28/README.md
@@ -23,7 +23,7 @@ Ultra-compact piezoresistive absolute pressure sensor with dual full-scale range
 import I2C
 import ElectricPower
 
-from "st-lps28.ato" import ST_LPS28
+from "atopile/st-lps28/st-lps28.ato" import ST_LPS28
 
 module Usage:
     """
@@ -48,6 +48,7 @@ module Usage:
 
     # Set I2C address (SA0 connected to GND = 0x5C, SA0 connected to VDD = 0x5D)
     assert pressure_sensor.i2c.address is 0x5C
+
 ```
 
 ## Pin Configuration

--- a/packages/st-lps28/usage.ato
+++ b/packages/st-lps28/usage.ato
@@ -6,7 +6,7 @@
 import I2C
 import ElectricPower
 
-from "st-lps28.ato" import ST_LPS28
+from "atopile/st-lps28/st-lps28.ato" import ST_LPS28
 
 module Usage:
     """

--- a/packages/st-lsm303agr/README.md
+++ b/packages/st-lsm303agr/README.md
@@ -34,6 +34,7 @@ module Usage:
 
     # I²C connection
     mcu.i2c ~ imu.i2c
+
 ```
 
 ## Contributing

--- a/packages/st-lsm6ds3tr-c/README.md
+++ b/packages/st-lsm6ds3tr-c/README.md
@@ -14,14 +14,10 @@ STMicroelectronics LSM6DS3TR-C is a system-in-package featuring a 3D digital acc
 ## Usage
 
 ```ato
-#pragma experiment("MODULE_TEMPLATING")
-#pragma experiment("BRIDGE_CONNECT")
-#pragma experiment("FOR_LOOP")
-
 import ElectricPower
 import I2C
 
-from "st-lsm6ds3tr-c.ato" import ST_LSM6DS3TR_C
+from "atopile/st-lsm6ds3tr-c/st-lsm6ds3tr-c.ato" import ST_LSM6DS3TR_C
 
 module Usage:
     """
@@ -44,6 +40,7 @@ module Usage:
     # Connect interfaces
     power_3v3 ~ imu.power
     i2c_bus ~ imu.i2c
+
 ```
 
 ## Contributing

--- a/packages/st-lsm6ds3tr-c/usage.ato
+++ b/packages/st-lsm6ds3tr-c/usage.ato
@@ -1,7 +1,7 @@
 import ElectricPower
 import I2C
 
-from "st-lsm6ds3tr-c.ato" import ST_LSM6DS3TR_C
+from "atopile/st-lsm6ds3tr-c/st-lsm6ds3tr-c.ato" import ST_LSM6DS3TR_C
 
 module Usage:
     """

--- a/packages/st-lsm6dso32/README.md
+++ b/packages/st-lsm6dso32/README.md
@@ -22,7 +22,7 @@ High-performance 6-axis inertial measurement unit (IMU) with 3-axis acceleromete
 import ElectricPower
 import I2C
 import ElectricLogic
-from "st-lsm6dso32.ato" import ST_LSM6DSO32
+from "atopile/st-lsm6dso32/st-lsm6dso32.ato" import ST_LSM6DSO32
 
 module Usage:
     """
@@ -67,6 +67,7 @@ module Usage:
     # int_pin = new ElectricLogic
     # int_pin.reference ~ power_3v3
     # int_pin ~ imu.int1
+
 ```
 
 ### Advanced Configurations

--- a/packages/st-lsm6dso32/usage.ato
+++ b/packages/st-lsm6dso32/usage.ato
@@ -2,7 +2,7 @@
 import ElectricPower
 import I2C
 import ElectricLogic
-from "st-lsm6dso32.ato" import ST_LSM6DSO32
+from "atopile/st-lsm6dso32/st-lsm6dso32.ato" import ST_LSM6DSO32
 
 module Usage:
     """

--- a/packages/st-lsm6dsox-lis3mdl/README.md
+++ b/packages/st-lsm6dsox-lis3mdl/README.md
@@ -52,7 +52,7 @@ The sensor combines:
 import ElectricPower
 import I2C
 
-from "st-lsm6dsox-lis3mdl.ato" import ST_LSM6DSOX_LIS3MDL
+from "atopile/st-lsm6dsox-lis3mdl/st-lsm6dsox-lis3mdl.ato" import ST_LSM6DSOX_LIS3MDL
 
 module Usage:
     """
@@ -94,6 +94,7 @@ module Usage:
     # - Read accelerometer/gyroscope data from LSM6DSOX at 0x6A/0x6B
     # - Read magnetometer data from LIS3MDL at 0x1C/0x1E
     # - LSM6DSOX can also read LIS3MDL data through its auxiliary interface
+
 ```
 
 ## Pinout

--- a/packages/st-lsm6dsox-lis3mdl/usage.ato
+++ b/packages/st-lsm6dsox-lis3mdl/usage.ato
@@ -5,7 +5,7 @@
 import ElectricPower
 import I2C
 
-from "st-lsm6dsox-lis3mdl.ato" import ST_LSM6DSOX_LIS3MDL
+from "atopile/st-lsm6dsox-lis3mdl/st-lsm6dsox-lis3mdl.ato" import ST_LSM6DSOX_LIS3MDL
 
 module Usage:
     """

--- a/packages/st-lsm6dsox/README.md
+++ b/packages/st-lsm6dsox/README.md
@@ -43,6 +43,7 @@ module Usage:
     # Configure I2C address (0x6A when SA0=GND, 0x6B when SA0=VDD)
     # Default configuration uses SA0=GND for address 0x6A
     assert imu.i2c.address is 0x6A
+
 ```
 
 ## Contributing

--- a/packages/st-lsm9ds1/README.md
+++ b/packages/st-lsm9ds1/README.md
@@ -34,7 +34,7 @@ Both units share the same I2C bus but are accessed using different slave address
 import ElectricPower
 import I2C
 
-from "st-lsm9ds1.ato" import ST_LSM9DS1
+from "atopile/st-lsm9ds1/st-lsm9ds1.ato" import ST_LSM9DS1
 
 module Usage:
     """
@@ -64,6 +64,7 @@ module Usage:
 
     # I2C address will be 0x6B (default when SDO_A_G pulled high by internal resistor)
     # Magnetometer uses separate address 0x1E on the same I2C bus
+
 ```
 
 ## Pin Configuration

--- a/packages/st-lsm9ds1/usage.ato
+++ b/packages/st-lsm9ds1/usage.ato
@@ -3,7 +3,7 @@
 import ElectricPower
 import I2C
 
-from "st-lsm9ds1.ato" import ST_LSM9DS1
+from "atopile/st-lsm9ds1/st-lsm9ds1.ato" import ST_LSM9DS1
 
 module Usage:
     """

--- a/packages/st-vl53l0x/README.md
+++ b/packages/st-vl53l0x/README.md
@@ -15,9 +15,15 @@ The ST VL53L0X is a Time-of-Flight (ToF) ranging sensor that provides accurate d
 ## Usage
 
 ```ato
-#pragma experiment("TRAITS")
-from "atopile/interfaces/interfaces.ato" import I2C, ElectricPower, ElectricLogic
-from "st-vl53l0x.ato" import ST_VL53L0X
+#pragma experiment("MODULE_TEMPLATING")
+#pragma experiment("BRIDGE_CONNECT")
+#pragma experiment("FOR_LOOP")
+
+import ElectricPower
+import I2C
+import ElectricLogic
+
+from "atopile/st-vl53l0x/st-vl53l0x.ato" import ST_VL53L0X
 
 module Usage:
     """
@@ -46,6 +52,7 @@ module Usage:
     i2c_bus ~ tof_sensor.i2c
     shutdown_control ~ tof_sensor.xshut
     interrupt_pin ~ tof_sensor.gpio1
+
 ```
 
 ## Interfaces

--- a/packages/st-vl53l0x/usage.ato
+++ b/packages/st-vl53l0x/usage.ato
@@ -6,7 +6,7 @@ import ElectricPower
 import I2C
 import ElectricLogic
 
-from "st-vl53l0x.ato" import ST_VL53L0X
+from "atopile/st-vl53l0x/st-vl53l0x.ato" import ST_VL53L0X
 
 module Usage:
     """

--- a/packages/st-vl53l1x/README.md
+++ b/packages/st-vl53l1x/README.md
@@ -27,7 +27,7 @@ import I2C
 import ElectricLogic
 
 # --- Package import ---
-from "st-vl53l1x.ato" import ST_VL53L1X
+from "atopile/st-vl53l1x/st-vl53l1x.ato" import ST_VL53L1X
 
 
 module Usage:
@@ -66,6 +66,7 @@ module Usage:
     # Optional: Connect interrupt pin
     # interrupt_line = new ElectricLogic
     # interrupt_line ~ sensor.gpio1
+
 ```
 
 ## Interface Details

--- a/packages/st-vl53l1x/usage.ato
+++ b/packages/st-vl53l1x/usage.ato
@@ -8,7 +8,7 @@ import I2C
 import ElectricLogic
 
 # --- Package import ---
-from "st-vl53l1x.ato" import ST_VL53L1X
+from "atopile/st-vl53l1x/st-vl53l1x.ato" import ST_VL53L1X
 
 
 module Usage:

--- a/packages/st-vl53l4cd/README.md
+++ b/packages/st-vl53l4cd/README.md
@@ -32,6 +32,7 @@ module Usage:
 
     # I²C connection
     mcu.i2c ~ tof_sensor.i2c
+
 ```
 
 ## Contributing

--- a/packages/st-vl53l4cx/README.md
+++ b/packages/st-vl53l4cx/README.md
@@ -32,6 +32,7 @@ module Usage:
 
     # I²C connection
     mcu.i2c ~ tof_sensor.i2c
+
 ```
 
 ## Contributing

--- a/packages/st-vl6180/README.md
+++ b/packages/st-vl6180/README.md
@@ -66,7 +66,7 @@ import ElectricPower
 import ElectricLogic
 import I2C
 
-from "st-vl6180.ato" import ST_VL6180
+from "atopile/st-vl6180/st-vl6180.ato" import ST_VL6180
 
 module Usage:
     """
@@ -113,6 +113,21 @@ module Usage:
     interrupt_pin = new ElectricLogic
     interrupt_pin.reference ~ power_3v3
     interrupt_pin ~ tof_sensor.gpio1
+
+    # --- Usage notes ---
+    # The VL6180 provides:
+    # - Time-of-Flight ranging: 0-100mm typical, up to 600mm possible
+    # - Ambient light sensing: 0-100k lux range
+    # - Independent of target color/reflectance
+    # - Low power: ~1.7mA during ranging at 10Hz
+    #
+    # Key features:
+    # - Default I2C address: 0x29 (can be changed in software)
+    # - GPIO0: Chip enable input / Data ready output
+    # - GPIO1: Programmable interrupt output
+    # - Fast ranging: up to 100Hz measurement rate
+    # - Integrated IR emitter (VCSEL) and photodiode
+
 ```
 
 ## Operation Modes

--- a/packages/st-vl6180/usage.ato
+++ b/packages/st-vl6180/usage.ato
@@ -6,7 +6,7 @@ import ElectricPower
 import ElectricLogic
 import I2C
 
-from "st-vl6180.ato" import ST_VL6180
+from "atopile/st-vl6180/st-vl6180.ato" import ST_VL6180
 
 module Usage:
     """

--- a/packages/tdpower-tdk20x/README.md
+++ b/packages/tdpower-tdk20x/README.md
@@ -19,6 +19,7 @@ module Usage:
     # connect power to converter
     power_in ~ converter.power_in
     converter.power_out ~ power_out
+
 ```
 
 ## Contributing

--- a/packages/testpoints/README.md
+++ b/packages/testpoints/README.md
@@ -22,8 +22,7 @@ A json file with testpoint data is generated in `build/<build_name>/<build_name>
 
 ```ato
 #pragma experiment("MODULE_TEMPLATING")
-from "atopile/testpoints/TestPoint.py" import TestPoint
-
+from "atopile/testpoints/testpoints.ato" import TestPoint
 module Usage:
     """
     Example of using testpoints
@@ -38,6 +37,7 @@ module Usage:
     basic_testpoint.contact ~ basic_tht_testpoint.contact
     big_smd_testpoint.contact ~ medium_tht_testpoint.contact
     basic_testpoint.contact ~ square_smd_testpoint.contact
+
 ```
 
 ## Contributing

--- a/packages/testpoints/usage.ato
+++ b/packages/testpoints/usage.ato
@@ -1,6 +1,5 @@
 #pragma experiment("MODULE_TEMPLATING")
-from "TestPoint.py" import TestPoint
-
+from "atopile/testpoints/testpoints.ato" import TestPoint
 module Usage:
     """
     Example of using testpoints

--- a/packages/ti-ads1115/README.md
+++ b/packages/ti-ads1115/README.md
@@ -15,28 +15,45 @@
 ## Usage
 
 ```ato
-import I2C
+#pragma experiment("BRIDGE_CONNECT")
+
 import ElectricPower
+import I2C
+import ElectricSignal
 
 from "atopile/ti-ads1115/ti-ads1115.ato" import TI_ADS1115
 
-module MyProject:
-    # Power and I2C bus
+module Usage:
+    """
+    Minimal usage example for `ti-ads1115`.
+    Demonstrates basic connections for the ADS1115 16-bit ADC.
+    """
+
+    # Power supply
     power_supply = new ElectricPower
+    power_supply.voltage = 3.3V +/- 5%
+
+    # I2C bus
     i2c_bus = new I2C
+    i2c_bus.frequency = 400kHz
 
     # ADC instance
     adc = new TI_ADS1115
 
-    # Configure power
-    power_supply.voltage = 3.3V +/- 5%
-
-    # Connect interfaces
+    # Connections
     power_supply ~ adc.power
     i2c_bus ~ adc.i2c
 
     # Configure address (tie ADDR to GND for 0x48 address)
     adc.addressor.address_lines[0].line ~ power_supply.lv
+
+    # Connect ADC inputs
+    analog_inputs = new ElectricSignal[4]
+    analog_inputs[0] ~ adc.inputs[0]
+    analog_inputs[1] ~ adc.inputs[1]
+    analog_inputs[2] ~ adc.inputs[2]
+    analog_inputs[3] ~ adc.inputs[3]
+
 ```
 
 ## Contributing

--- a/packages/ti-ads1115/usage.ato
+++ b/packages/ti-ads1115/usage.ato
@@ -4,7 +4,7 @@ import ElectricPower
 import I2C
 import ElectricSignal
 
-from "ti-ads1115.ato" import TI_ADS1115
+from "atopile/ti-ads1115/ti-ads1115.ato" import TI_ADS1115
 
 module Usage:
     """

--- a/packages/ti-ads7830/README.md
+++ b/packages/ti-ads7830/README.md
@@ -13,7 +13,7 @@ The TI ADS7830 is an 8-bit, 8-channel analog-to-digital converter with an I²C i
 import ElectricPower
 import I2C
 
-from "ti-ads7830.ato" import TI_ADS7830
+from "atopile/ti-ads7830/ti-ads7830.ato" import TI_ADS7830
 
 module Usage:
     """
@@ -38,6 +38,7 @@ module Usage:
 
     # --- Set I2C address (optional - default is 0x48) ---
     # i2c_bus.address = 0x48
+
 ```
 
 ## Contributing

--- a/packages/ti-ads7830/usage.ato
+++ b/packages/ti-ads7830/usage.ato
@@ -6,7 +6,7 @@
 import ElectricPower
 import I2C
 
-from "ti-ads7830.ato" import TI_ADS7830
+from "atopile/ti-ads7830/ti-ads7830.ato" import TI_ADS7830
 
 module Usage:
     """

--- a/packages/ti-bq25185/README.md
+++ b/packages/ti-bq25185/README.md
@@ -24,7 +24,7 @@ The BQ25185 is a highly integrated 1A single-input, single-cell Li-Ion and Li-Po
 import ElectricPower
 import Resistor
 
-from "ti-bq25185.ato" import TI_BQ25185
+from "atopile/ti-bq25185/ti-bq25185.ato" import TI_BQ25185
 
 module Usage:
     """
@@ -63,6 +63,7 @@ module Usage:
     # Status LEDs can be connected to status_1 and status_2 pins
     # status_1: Fault indication (active low)
     # status_2: Charge status (active low during charging)
+
 ```
 
 ## Hardware Features

--- a/packages/ti-bq25185/usage.ato
+++ b/packages/ti-bq25185/usage.ato
@@ -4,7 +4,7 @@
 import ElectricPower
 import Resistor
 
-from "ti-bq25185.ato" import TI_BQ25185
+from "atopile/ti-bq25185/ti-bq25185.ato" import TI_BQ25185
 
 module Usage:
     """

--- a/packages/ti-dac6578/README.md
+++ b/packages/ti-dac6578/README.md
@@ -23,37 +23,48 @@ Texas Instruments DAC6578 8-Channel 10-Bit Digital-to-Analog Converter with I2C 
 ```ato
 import ElectricPower
 import I2C
+import Electrical
 
-from "ti-dac6578.ato" import TI_DAC6578
+from "atopile/ti-dac6578/ti-dac6578.ato" import TI_DAC6578
+
+module MCU:
+    """Host MCU providing I²C bus and power rail."""
+
+    power = new ElectricPower
+    i2c = new I2C
+
 
 module Usage:
     """Complete usage example for TI_DAC6578 DAC."""
 
+    # MCU & DAC
+    mcu = new MCU
     dac = new TI_DAC6578
 
-    # Connect power supply (3.3V example)
-    power_3v3 = new ElectricPower
-    power_3v3.voltage = 3.3V +/- 5%
-    power_3v3 ~ dac.power
+    # Shared 3V3 rail
+    power = new ElectricPower
+    power.voltage = 3.3V +/- 5%
+    power ~ mcu.power
+    power ~ dac.power
 
-    # Connect I2C bus
-    i2c_bus = new I2C
-    i2c_bus.frequency = 400kHz
-    i2c_bus ~ dac.i2c
+    # I²C connection
+    mcu.i2c ~ dac.i2c
 
     # Note: DAC module includes 4.7k I2C pull-ups internally
 
     # Reference voltage (using power supply)
-    dac.vref ~ power_3v3.hv
+    dac.vref ~ power.hv
 
     # DAC outputs can be connected to external circuits
+    # Example: connecting to test points or analog circuits
     # dac.outputs[0] ~ analog_circuit_input_a  # Channel A
     # dac.outputs[1] ~ analog_circuit_input_b  # Channel B
     # ... etc for channels 2-7 (C through H)
 
     # Control signals can be connected to microcontroller pins:
-    # dac.clear_n ~ microcontroller.gpio_clear
-    # dac.ldac_n ~ microcontroller.gpio_ldac
+    # dac.clear_n ~ mcu.gpio_clear
+    # dac.ldac_n ~ mcu.gpio_ldac
+
 ```
 
 ## Pin Configuration

--- a/packages/ti-dac6578/usage.ato
+++ b/packages/ti-dac6578/usage.ato
@@ -2,7 +2,7 @@ import ElectricPower
 import I2C
 import Electrical
 
-from "ti-dac6578.ato" import TI_DAC6578
+from "atopile/ti-dac6578/ti-dac6578.ato" import TI_DAC6578
 
 module MCU:
     """Host MCU providing I²C bus and power rail."""

--- a/packages/ti-dac7578/README.md
+++ b/packages/ti-dac7578/README.md
@@ -21,11 +21,13 @@ Texas Instruments DAC7578 8-Channel 12-Bit Digital-to-Analog Converter with I2C 
 
 ```ato
 #pragma experiment("TRAITS")
+#pragma experiment("FOR_LOOP")
+#pragma experiment("BRIDGE_CONNECT")
 import I2C
 import ElectricPower
 import Resistor
 
-from "ti-dac7578.ato" import TI_DAC7578
+from "atopile/ti-dac7578/ti-dac7578.ato" import TI_DAC7578
 
 module Usage:
     """
@@ -60,6 +62,7 @@ module Usage:
     # To use 0x49 instead, uncomment: dac.i2c.address = 0x49
 
     # DAC outputs can be connected to external circuits
+    # Example: connecting to test points or other analog circuits
     # dac.dac_out_a ~ analog_circuit_input_a
     # dac.dac_out_b ~ analog_circuit_input_b
     # ... etc for channels C through H
@@ -67,6 +70,7 @@ module Usage:
     # Control signals can be connected to microcontroller pins:
     # dac.clear_n ~ microcontroller.gpio_clear
     # dac.ldac_n ~ microcontroller.gpio_ldac
+
 ```
 
 ## Pin Configuration

--- a/packages/ti-dac7578/usage.ato
+++ b/packages/ti-dac7578/usage.ato
@@ -5,7 +5,7 @@ import I2C
 import ElectricPower
 import Resistor
 
-from "ti-dac7578.ato" import TI_DAC7578
+from "atopile/ti-dac7578/ti-dac7578.ato" import TI_DAC7578
 
 module Usage:
     """

--- a/packages/ti-drv2605l/README.md
+++ b/packages/ti-drv2605l/README.md
@@ -25,7 +25,6 @@ Advanced haptic driver IC for Linear Resonant Actuators (LRA) and Eccentric Rota
 ## Usage
 
 ```ato
-#pragma experiment("TRAITS")
 #pragma experiment("MODULE_TEMPLATING")
 #pragma experiment("BRIDGE_CONNECT")
 #pragma experiment("FOR_LOOP")
@@ -33,7 +32,7 @@ Advanced haptic driver IC for Linear Resonant Actuators (LRA) and Eccentric Rota
 import ElectricPower
 import I2C
 
-from "ti-drv2605l.ato" import TI_DRV2605L
+from "atopile/ti-drv2605l/ti-drv2605l.ato" import TI_DRV2605L
 
 module Usage:
     """
@@ -64,6 +63,7 @@ module Usage:
 
     # Connect haptic motor/actuator
     haptic_motor ~ haptic_driver.haptic_output
+
 ```
 
 ## External Interfaces

--- a/packages/ti-drv2605l/usage.ato
+++ b/packages/ti-drv2605l/usage.ato
@@ -5,7 +5,7 @@
 import ElectricPower
 import I2C
 
-from "ti-drv2605l.ato" import TI_DRV2605L
+from "atopile/ti-drv2605l/ti-drv2605l.ato" import TI_DRV2605L
 
 module Usage:
     """

--- a/packages/ti-hdc3022/README.md
+++ b/packages/ti-hdc3022/README.md
@@ -23,7 +23,7 @@ The HDC3022 is a digital temperature and humidity sensor from Texas Instruments 
 import ElectricPower
 import I2C
 
-from "ti-hdc3022.ato" import TI_HDC3022
+from "atopile/ti-hdc3022/ti-hdc3022.ato" import TI_HDC3022
 
 module Usage:
     """
@@ -48,6 +48,7 @@ module Usage:
 
     # Set I2C address (default 0x44 with both address pins low)
     temp_humidity_sensor.i2c.address = 0x44
+
 ```
 
 ## Technical Specifications

--- a/packages/ti-hdc3022/usage.ato
+++ b/packages/ti-hdc3022/usage.ato
@@ -4,7 +4,7 @@
 import ElectricPower
 import I2C
 
-from "ti-hdc3022.ato" import TI_HDC3022
+from "atopile/ti-hdc3022/ti-hdc3022.ato" import TI_HDC3022
 
 module Usage:
     """

--- a/packages/ti-ina228/README.md
+++ b/packages/ti-ina228/README.md
@@ -26,44 +26,126 @@ The INA228 is a high-precision current and power monitoring IC from Texas Instru
 ```ato
 #pragma experiment("TRAITS")
 #pragma experiment("BRIDGE_CONNECT")
+#pragma experiment("FOR_LOOP")
 import ElectricPower
+import ElectricLogic
 import I2C
-from "ti-ina228.ato" import TI_INA228
+from "atopile/ti-ina228/ti-ina228.ato" import TI_INA228
 
 module Usage:
     """
-    Minimal usage example for TI INA228 power monitor.
+    Comprehensive usage examples for TI INA228 power monitor.
 
-    This example shows how to connect the INA228 to monitor current through
-    a shunt resistor with 3.3V supply and I2C interface.
+    This example demonstrates:
+    - Multiple INA228 devices on a single I2C bus with different addresses
+    - Monitoring various current ranges (100mA to 10A)
+    - Different power rail configurations (3.3V, 5V, 12V, 48V)
     """
 
-    # Power rails
-    supply = new ElectricPower
-    load = new ElectricPower
-    supply.voltage = 3.3V +/- 5%
-
-    # I2C bus
+    # === Shared I2C bus ===
     i2c = new I2C
+    i2c.frequency = 400kHz  # Fast mode
 
-    # Current monitor
-    current_monitor = new TI_INA228
-    current_monitor.max_current = 2A
-    current_monitor.power ~ supply
+    # === Power rails ===
+    # Supply voltage for all INA228 devices (3.3V logic)
+    supply_3v3 = new ElectricPower
+    supply_3v3.voltage = 3.3V +/- 5%
 
-    # Wiring - bridge the current monitor in the power path
-    supply ~> current_monitor ~> load
-    current_monitor.i2c ~ i2c
+    # === Example 1: Low current USB device monitoring (100mA max) ===
+    # USB 5V rail monitoring
+    usb_5v_in = new ElectricPower
+    usb_5v_out = new ElectricPower
+    usb_5v_in.voltage = 5V +/- 10%
 
-    # I2C address configuration
-    # INA228 supports 16 addresses (0x40-0x4F) based on A0/A1 connections:
-    # A0, A1 can each connect to: GND=0, VS=1, SDA=2, SCL=3
-    # Address = 0x40 + (A1_config << 2) + (A0_config << 1)
-    # Examples:
-    # - A0=GND, A1=GND: 0x40 (both pins to ground)
-    # - A0=VS,  A1=GND: 0x42 (A0 to supply, A1 to ground)
-    # - A0=SDA, A1=SCL: 0x4E (A0 to SDA, A1 to SCL)
-    current_monitor.i2c.address = 0x40  # A0=GND, A1=GND configuration
+    usb_monitor = new TI_INA228
+    usb_monitor.max_current = 100mA
+    usb_monitor.power ~ supply_3v3
+    usb_monitor.i2c ~ i2c
+    usb_monitor.i2c.address = 0x40  # A0=GND, A1=GND
+
+    # Insert monitor in USB power path
+    usb_5v_in ~> usb_monitor ~> usb_5v_out
+
+    # === Example 2: Medium current 3.3V rail monitoring (2A max) ===
+    # Main 3.3V system rail
+    main_3v3_in = new ElectricPower
+    main_3v3_out = new ElectricPower
+    main_3v3_in.voltage = 3.3V +/- 5%
+
+    main_3v3_monitor = new TI_INA228
+    main_3v3_monitor.max_current = 2A
+    main_3v3_monitor.power ~ supply_3v3
+    main_3v3_monitor.i2c ~ i2c
+    main_3v3_monitor.i2c.address = 0x41  # A0=VS, A1=GND
+
+    # Insert monitor in 3.3V power path
+    main_3v3_in ~> main_3v3_monitor ~> main_3v3_out
+
+    # === Example 3: High current 12V rail monitoring (5A max) ===
+    # 12V power supply monitoring
+    supply_12v_in = new ElectricPower
+    supply_12v_out = new ElectricPower
+    supply_12v_in.voltage = 12V +/- 5%
+
+    supply_12v_monitor = new TI_INA228
+    supply_12v_monitor.max_current = 5A
+    supply_12v_monitor.power ~ supply_3v3
+    supply_12v_monitor.i2c ~ i2c
+    supply_12v_monitor.i2c.address = 0x42  # A0=SDA, A1=GND
+
+    # Insert monitor in 12V power path
+    supply_12v_in ~> supply_12v_monitor ~> supply_12v_out
+
+    # === Example 4: Very high current motor drive monitoring (10A max) ===
+    # Motor power monitoring
+    motor_pwr_in = new ElectricPower
+    motor_pwr_out = new ElectricPower
+    motor_pwr_in.voltage = 24V +/- 10%
+
+    motor_monitor = new TI_INA228
+    motor_monitor.max_current = 10A
+    motor_monitor.power ~ supply_3v3
+    motor_monitor.i2c ~ i2c
+    motor_monitor.i2c.address = 0x43  # A0=SCL, A1=GND
+
+    # Insert monitor in motor power path
+    motor_pwr_in ~> motor_monitor ~> motor_pwr_out
+
+    # === Example 5: High voltage PoE monitoring (48V, 500mA max) ===
+    # Power over Ethernet monitoring
+    poe_in = new ElectricPower
+    poe_out = new ElectricPower
+    poe_in.voltage = 48V +/- 10%
+
+    poe_monitor = new TI_INA228
+    poe_monitor.max_current = 500mA
+    poe_monitor.power ~ supply_3v3
+    poe_monitor.i2c ~ i2c
+    poe_monitor.i2c.address = 0x44  # A0=GND, A1=VS
+
+    # Insert monitor in PoE power path
+    poe_in ~> poe_monitor ~> poe_out
+
+    # === Example 6: Battery discharge monitoring (3.7V Li-Ion, 3A max) ===
+    # Battery monitoring with alert
+    battery_in = new ElectricPower
+    battery_out = new ElectricPower
+    battery_in.voltage = 3.7V +/- 0.5V  # Li-Ion voltage range
+
+    battery_monitor = new TI_INA228
+    battery_monitor.max_current = 3A
+    battery_monitor.power ~ supply_3v3
+    battery_monitor.i2c ~ i2c
+    battery_monitor.i2c.address = 0x48  # A0=GND, A1=SDA
+
+    # Insert monitor in battery discharge path
+    battery_in ~> battery_monitor ~> battery_out
+
+    # Connect alert output to microcontroller interrupt pin
+    # Note: The INA228 module includes built-in 10k pullup on alert pin
+    mcu_interrupt = new ElectricLogic
+    mcu_interrupt ~ battery_monitor.alert
+
 ```
 
 ## Interface Details

--- a/packages/ti-ina228/usage.ato
+++ b/packages/ti-ina228/usage.ato
@@ -4,7 +4,7 @@
 import ElectricPower
 import ElectricLogic
 import I2C
-from "ti-ina228.ato" import TI_INA228
+from "atopile/ti-ina228/ti-ina228.ato" import TI_INA228
 
 module Usage:
     """

--- a/packages/ti-ina232/README.md
+++ b/packages/ti-ina232/README.md
@@ -25,38 +25,74 @@ The INA232 is a high-side/low-side bidirectional current and power monitor with 
 #pragma experiment("BRIDGE_CONNECT")
 import ElectricPower
 import I2C
+import Resistor
 
-from "ti-ina232.ato" import TI_INA232
+from "atopile/ti-ina232/ti-ina232.ato" import TI_INA232
 
 module Usage:
     """
-    Minimal usage example for ti-ina232 current monitor.
-    Measures load current/power on a 12V rail.
+    Usage example for ti-ina232 current monitor showing all 4 possible addresses.
+    Tests INA232A addressing scheme with different A0 pin connections.
     """
 
     # Power rails
     supply = new ElectricPower
-    load = new ElectricPower
+    load1 = new ElectricPower
+    load2 = new ElectricPower
+    load3 = new ElectricPower
+    load4 = new ElectricPower
     supply.voltage = 12V +/- 5%
 
-    # I2C bus
-    i2c = new I2C
-
-    # Device instance
-    sensor = new TI_INA232
-    sensor.max_current = 2A
-    sensor.power ~ supply
-
-    # Wiring - using bridge functionality
-    supply ~> sensor ~> load
-    sensor.i2c ~ i2c
-
-    # Address automatically set by addressor (0x40 base address when A0=0)
-    # Pull-up resistors are built into the module
     # Device power supply (3.3V)
     device_power = new ElectricPower
     device_power.voltage = 3.3V +/- 5%
-    device_power ~ sensor.power
+
+    # I2C bus with pull-up resistors
+    i2c = new I2C
+    i2c.reference_shim ~ device_power
+
+    # Four sensors with different address configurations
+    sensor1 = new TI_INA232  # A0 = GND -> 0x40
+    sensor2 = new TI_INA232  # A0 = VS -> 0x41
+    sensor3 = new TI_INA232  # A0 = SDA -> 0x42
+    sensor4 = new TI_INA232  # A0 = SCL -> 0x43
+
+    # Configure sensors with different current ranges
+    sensor1.max_current = 0.1A   # Low current monitoring
+    sensor2.max_current = 1A   # Medium current monitoring
+    sensor3.max_current = 5A   # High current monitoring
+    sensor4.max_current = 10A  # Very high current monitoring
+
+    # Connect power and I2C to all sensors
+    for sensor in [sensor1, sensor2, sensor3, sensor4]:
+        sensor.power ~ device_power
+        sensor.i2c ~ i2c
+
+    # Address configuration via A0 pin connections:
+    # Sensor 1: A0 to GND (0x40)
+    sensor1.i2c.address = 0x40
+
+    # Sensor 2: A0 to VS (0x41)
+    sensor2.i2c.address = 0x41
+
+    # Sensor 3: A0 to SDA (0x42)
+    sensor3.i2c.address = 0x42
+
+    # Sensor 4: A0 to SCL (0x43)
+    sensor4.i2c.address = 0x43
+
+    # Wiring - using bridge functionality for each sensor
+    supply ~> sensor1 ~> load1
+    supply ~> sensor2 ~> load2
+    supply ~> sensor3 ~> load3
+    supply ~> sensor4 ~> load4
+
+    # Expected addresses and current ranges:
+    # sensor1: 0x40 (A0=GND) - 1A max current
+    # sensor2: 0x41 (A0=VS) - 2A max current
+    # sensor3: 0x42 (A0=SDA) - 5A max current
+    # sensor4: 0x43 (A0=SCL) - 10A max current
+
 ```
 
 ## Hardware Features

--- a/packages/ti-ina232/usage.ato
+++ b/packages/ti-ina232/usage.ato
@@ -5,7 +5,7 @@ import ElectricPower
 import I2C
 import Resistor
 
-from "ti-ina232.ato" import TI_INA232
+from "atopile/ti-ina232/ti-ina232.ato" import TI_INA232
 
 module Usage:
     """

--- a/packages/ti-ina237/README.md
+++ b/packages/ti-ina237/README.md
@@ -22,7 +22,8 @@ High-precision digital power monitor with 16-bit delta-sigma ADC designed for cu
 import I2C
 import ElectricPower
 import ElectricLogic
-from "ti-ina237.ato" import TI_INA237
+import Resistor
+from "atopile/ti-ina237/ti-ina237.ato" import TI_INA237
 
 module Usage:
     """
@@ -61,6 +62,7 @@ module Usage:
     # Set I2C address to 0x40 (base address when A1=0, A0=0)
     # Address pins will be pulled down internally or externally
     power_monitor.i2c.address = 0x40
+
 ```
 
 ## Contributing

--- a/packages/ti-ina237/usage.ato
+++ b/packages/ti-ina237/usage.ato
@@ -5,7 +5,7 @@ import I2C
 import ElectricPower
 import ElectricLogic
 import Resistor
-from "ti-ina237.ato" import TI_INA237
+from "atopile/ti-ina237/ti-ina237.ato" import TI_INA237
 
 module Usage:
     """

--- a/packages/ti-ina238/README.md
+++ b/packages/ti-ina238/README.md
@@ -21,11 +21,10 @@ The module exposes an I²C interface and bridges a high-side shunt resistor to m
 #pragma experiment("MODULE_TEMPLATING")
 #pragma experiment("FOR_LOOP")
 #pragma experiment("BRIDGE_CONNECT")
-
 import ElectricPower
 import I2C
 
-from "ti-ina238.ato" import TI_INA238
+from "atopile/ti-ina238/ti-ina238.ato" import TI_INA238
 
 module Usage:
     """
@@ -52,6 +51,7 @@ module Usage:
 
     # Address automatically set by addressor (0x40 base address when A0=A1=0)
     # Pull-up resistors are built into the module
+
 ```
 
 ## Interface Details

--- a/packages/ti-ina238/usage.ato
+++ b/packages/ti-ina238/usage.ato
@@ -4,7 +4,7 @@
 import ElectricPower
 import I2C
 
-from "ti-ina238.ato" import TI_INA238
+from "atopile/ti-ina238/ti-ina238.ato" import TI_INA238
 
 module Usage:
     """

--- a/packages/ti-ina3221/README.md
+++ b/packages/ti-ina3221/README.md
@@ -25,7 +25,13 @@ The INA3221 is a triple-channel, high-side current and power monitor with an I2C
 import ElectricPower
 import I2C
 
-from "ti-ina3221.ato" import TI_INA3221
+from "atopile/ti-ina3221/ti-ina3221.ato" import TI_INA3221
+
+module Sink:
+    """
+    mock sink device for testing
+    """
+    power = new ElectricPower
 
 module Usage:
     """
@@ -35,6 +41,7 @@ module Usage:
 
     # Create current monitor instance
     current_monitor = new TI_INA3221
+    sinks = new Sink[3]
 
     # Main power supply for the IC (3.3V or 5V)
     power_3v3 = new ElectricPower
@@ -42,29 +49,23 @@ module Usage:
 
     # External I2C bus
     i2c_bus = new I2C
-    i2c_bus.frequency = 400kHz
 
     # Example monitored power rails
-    rail_5v = new ElectricPower
-    rail_5v.voltage = 5V +/- 5%
-
-    rail_12v = new ElectricPower
-    rail_12v.voltage = 12V +/- 5%
-
-    rail_battery = new ElectricPower
-    rail_battery.voltage = 7.4V +/- 10%  # 2S Li-ion battery example
+    power_5v = new ElectricPower
+    power_5v.voltage = 5V +/- 5%
 
     # Connect interfaces
     power_3v3 ~ current_monitor.power
     i2c_bus ~ current_monitor.i2c
 
     # Connect monitored channels (bridgeable)
-    rail_5v ~> current_monitor.channels[0] ~> power_3v3  # Example: 5V rail powering 3.3V system
-    rail_12v ~> current_monitor.channels[1]              # Example: 12V rail monitoring
-    rail_battery ~> current_monitor.channels[2]         # Example: Battery rail monitoring
+    power_5v ~> current_monitor.channels[0] ~> sinks[0].power
+    power_5v ~> current_monitor.channels[1] ~> sinks[1].power
+    power_5v ~> current_monitor.channels[2] ~> sinks[2].power
 
     # Set I2C address (default 0x40 with A0 pin low)
     current_monitor.i2c.address = 0x40
+
 ```
 
 ## Technical Specifications

--- a/packages/ti-ina3221/usage.ato
+++ b/packages/ti-ina3221/usage.ato
@@ -4,7 +4,7 @@
 import ElectricPower
 import I2C
 
-from "ti-ina3221.ato" import TI_INA3221
+from "atopile/ti-ina3221/ti-ina3221.ato" import TI_INA3221
 
 module Sink:
     """

--- a/packages/ti-iso1640qdwrq1/README.md
+++ b/packages/ti-iso1640qdwrq1/README.md
@@ -13,14 +13,21 @@ import ElectricPower
 from "atopile/ti-iso1640qdwrq1/ti-iso1640qdwrq1.ato" import TI_ISO1640QDWRQ1
 
 module Microcontroller:
+    """Example microcontroller"""
     i2c = new I2C
     power = new ElectricPower
 
 module Sensor:
+    """Example sensor"""
     i2c = new I2C
     power = new ElectricPower
 
 module Example:
+    """
+    Example usage of ISO1640QDWRQ1 I2C isolator
+    Connect a microcontroller to a sensor via an I2C isolator
+    """
+
     # Components
     micro = new Microcontroller
     sensor = new Sensor
@@ -48,6 +55,7 @@ module Example:
     # Isolated power
     power_iso_3v3 ~ sensor.power
     power_iso_3v3 ~ isolator.power_rails[1]
+
 ```
 
 ## Features

--- a/packages/ti-iso1640qdwrq1/usage.ato
+++ b/packages/ti-iso1640qdwrq1/usage.ato
@@ -3,7 +3,7 @@
 import I2C
 import ElectricPower
 
-from "ti-iso1640qdwrq1.ato" import TI_ISO1640QDWRQ1
+from "atopile/ti-iso1640qdwrq1/ti-iso1640qdwrq1.ato" import TI_ISO1640QDWRQ1
 
 module Microcontroller:
     """Example microcontroller"""

--- a/packages/ti-lv2842x/README.md
+++ b/packages/ti-lv2842x/README.md
@@ -1,1 +1,82 @@
 The LV2841 and LV2842 are PWM DC/DC buck (stepdown) regulators. With a wide input range from 4V-40V, they are suitable for a wide range of application from industrial to automotive for power conditioning from unregulated source.
+
+## Usage
+
+```ato
+#pragma experiment("MODULE_TEMPLATING")
+#pragma experiment("FOR_LOOP")
+#pragma experiment("BRIDGE_CONNECT")
+import ElectricPower
+
+from "atopile/ti-lv2842x/ti-lv2842x.ato" import TI_LV2842X
+
+module Usage:
+    """
+    Test design
+    """
+
+
+    # --- 36V to 15V ---
+    power_36v = new ElectricPower
+    assert power_36v.voltage within 36V +/- 10%
+    power_15v = new ElectricPower
+    assert power_15v.voltage within 15V +/- 5%
+    regulator42_15v = new TI_LV2842X
+    regulator42_15v.power_in ~ power_36v
+    regulator42_15v.power_out ~ power_15v
+    regulator42_15v.power_out.max_current = 500mA
+
+    # --- 38V to 24V ---
+    power_38v = new ElectricPower
+    assert power_38v.voltage within 38V +/- 10%
+    power_24v = new ElectricPower
+    assert power_24v.voltage within 24V +/- 5%
+    regulator38_24v = new TI_LV2842X
+    regulator38_24v.power_in ~ power_38v
+    regulator38_24v.power_out ~ power_24v
+    regulator38_24v.power_out.max_current = 400mA
+
+    # --- 24V to 12V ---
+    # power_24v = new ElectricPower
+    # assert power_24v.voltage within 24V +/- 5%
+    power_12v = new ElectricPower
+    assert power_12v.voltage within 12V +/- 5%
+    regulator41_12v = new TI_LV2842X
+    regulator41_12v.power_in ~ power_24v
+    regulator41_12v.power_out ~ power_12v
+    regulator41_12v.power_out.max_current = 200mA
+
+    # --- 12V to 5V ---
+    power_5v = new ElectricPower
+    assert power_5v.voltage within 5V +/- 5%
+    regulator40_5v = new TI_LV2842X
+    regulator40_5v.power_in ~ power_12v
+    regulator40_5v.power_out ~ power_5v
+    regulator40_5v.power_out.max_current = 50mA
+
+    # --- 5V to 0.8V ---
+    power_0v8 = new ElectricPower
+    assert power_0v8.voltage within 0.8V +/- 5%
+    regulator42_0v8 = new TI_LV2842X
+    regulator42_0v8.power_in ~ power_5v
+    regulator42_0v8.power_out ~ power_0v8
+    regulator42_0v8.power_out.max_current = 50mA
+
+    # Big inductor
+    power_42v = new ElectricPower
+    assert power_42v.voltage within 42V +/- 10%
+    power_8v = new ElectricPower
+    assert power_8v.voltage within 8V +/- 5%
+    regulator42_big_inductor = new TI_LV2842X
+    regulator42_big_inductor.power_in ~ power_42v
+    regulator42_big_inductor.power_out ~ power_8v
+    regulator42_big_inductor.power_out.max_current = 10mA
+
+    # Small inductor
+    power_10v = new ElectricPower
+    assert power_10v.voltage within 10V +/- 5%
+    regulator42_small_inductor = new TI_LV2842X
+    regulator42_small_inductor.power_in ~ power_12v
+    regulator42_small_inductor.power_out ~ power_10v
+    regulator42_small_inductor.power_out.max_current = 600mA
+```

--- a/packages/ti-max3243/README.md
+++ b/packages/ti-max3243/README.md
@@ -25,7 +25,7 @@ import ElectricPower, ElectricLogic
 import RS232, UART
 import Resistor, Capacitor
 
-from "ti-max3243.ato" import TI_MAX3243
+from "atopile/ti-max3243/ti-max3243.ato" import TI_MAX3243
 
 from "parts/Ckmtw_D_DMR009PF_D002/Ckmtw_D_DMR009PF_D002.ato" import Ckmtw_D_DMR009PF_D002_package
 from "parts/Ckmtw_D_DMR009PM_D002/Ckmtw_D_DMR009PM_D002.ato" import Ckmtw_D_DMR009PM_D002_package
@@ -78,18 +78,13 @@ module Usage:
     invalid_indicator.reference ~ power_3v3
     invalid_indicator ~ rs232_transceiver.ninvalid
 
-    # DE-9 RS-232 Male connector
     de9_rs232_male = new DE9RS232Male
     de9_rs232_male.rs232 ~ rs232_transceiver.rs232
 
-    # Override net names for cleaner schematic
     power_3v3.hv.override_net_name = "Vin"
     power_3v3.lv.override_net_name = "VGND"
 
 module DE9RS232Female:
-    """
-    DE-9 Female RS-232 connector module
-    """
     package = new Ckmtw_D_DMR009PF_D002_package
     rs232 = new RS232
 
@@ -106,10 +101,8 @@ module DE9RS232Female:
     package.MH1 ~ rs232.reference_shim.lv
     package.MH2 ~ rs232.reference_shim.lv
 
+
 module DE9RS232Male:
-    """
-    DE-9 Male RS-232 connector module
-    """
     package = new Ckmtw_D_DMR009PM_D002_package
     rs232 = new RS232
 
@@ -125,6 +118,7 @@ module DE9RS232Male:
 
     package.MH1 ~ rs232.reference_shim.lv
     package.MH2 ~ rs232.reference_shim.lv
+
 ```
 
 ## Interfaces

--- a/packages/ti-tca4307/README.md
+++ b/packages/ti-tca4307/README.md
@@ -25,7 +25,7 @@ The TCA4307 is a hot-swappable I²C bus buffer designed for I/O card insertion i
 import ElectricPower
 import I2C
 
-from "ti-tca4307.ato" import TI_TCA4307
+from "atopile/ti-tca4307/ti-tca4307.ato" import TI_TCA4307
 
 module Usage:
     """
@@ -54,6 +54,7 @@ module Usage:
 
     # Connect power supply
     power_3v3 ~ buffer.power
+
 ```
 
 ## Interface Details

--- a/packages/ti-tca4307/usage.ato
+++ b/packages/ti-tca4307/usage.ato
@@ -5,7 +5,7 @@
 import ElectricPower
 import I2C
 
-from "ti-tca4307.ato" import TI_TCA4307
+from "atopile/ti-tca4307/ti-tca4307.ato" import TI_TCA4307
 
 module Usage:
     """

--- a/packages/ti-tca6408/README.md
+++ b/packages/ti-tca6408/README.md
@@ -14,7 +14,8 @@ import ElectricPower
 import I2C
 
 # --- Package import ---
-from "ti-tca6408.ato" import TI_TCA6408
+from "atopile/ti-tca6408/ti-tca6408.ato" import TI_TCA6408
+
 
 module Usage:
     """
@@ -46,6 +47,7 @@ module Usage:
     # Provide logic references
     power_3v3 ~ i2c_bus.scl.reference
     power_3v3 ~ i2c_bus.sda.reference
+
 ```
 
 ## Contributing

--- a/packages/ti-tca6408/usage.ato
+++ b/packages/ti-tca6408/usage.ato
@@ -7,7 +7,7 @@ import ElectricPower
 import I2C
 
 # --- Package import ---
-from "ti-tca6408.ato" import TI_TCA6408
+from "atopile/ti-tca6408/ti-tca6408.ato" import TI_TCA6408
 
 
 module Usage:

--- a/packages/ti-tca8418/README.md
+++ b/packages/ti-tca8418/README.md
@@ -21,7 +21,7 @@ The TCA8418 is a versatile I2C-controlled keypad matrix scanner and GPIO expande
 import I2C
 import ElectricPower
 
-from "ti-tca8418.ato" import TI_TCA8418
+from "atopile/ti-tca8418/ti-tca8418.ato" import TI_TCA8418
 
 module Usage:
     """
@@ -48,6 +48,7 @@ module Usage:
     # GPIO row pins are available as keypad_controller.gpio_rows[0] through gpio_rows[7]
     # GPIO column pins are available as keypad_controller.gpio_cols[0] through gpio_cols[9]
     # Interrupt pin is available as keypad_controller.interrupt
+
 ```
 
 ## Pin Configuration

--- a/packages/ti-tca8418/usage.ato
+++ b/packages/ti-tca8418/usage.ato
@@ -3,7 +3,7 @@
 import I2C
 import ElectricPower
 
-from "ti-tca8418.ato" import TI_TCA8418
+from "atopile/ti-tca8418/ti-tca8418.ato" import TI_TCA8418
 
 module Usage:
     """

--- a/packages/ti-tca9548a/README.md
+++ b/packages/ti-tca9548a/README.md
@@ -14,12 +14,19 @@
 ## Usage
 
 ```ato
-import I2C
+#pragma experiment("BRIDGE_CONNECT")
+
 import ElectricPower
+import I2C
 
 from "atopile/ti-tca9548a/ti-tca9548a.ato" import TI_TCA9548A
 
-module MyProject:
+module Usage:
+    """
+    Minimal usage example for `ti-tca9548a`.
+    Demonstrates basic connections for the TCA9548A I2C multiplexer.
+    """
+
     # Power supply
     power_supply = new ElectricPower
     power_supply.voltage = 3.3V +/- 5%
@@ -35,17 +42,18 @@ module MyProject:
     power_supply ~ mux.power
     main_i2c ~ mux.i2c
 
-    # Configure address (tie A0, A1, A2 to GND for 0x70 address)
-    mux.addressor.address_lines[0].line ~ power_supply.lv
-    mux.addressor.address_lines[1].line ~ power_supply.lv
-    mux.addressor.address_lines[2].line ~ power_supply.lv
+    # Configure address - addressor will automatically set the address lines
+    # Valid addresses are 0x70 to 0x77
+    mux.i2c.address = 0x70
 
     # Connect to I2C channels as needed
+    # Each channel is isolated and can have different devices
     channel_0 = new I2C
     channel_1 = new I2C
 
     channel_0 ~ mux.i2cs[0]
     channel_1 ~ mux.i2cs[1]
+
 ```
 
 ## Contributing

--- a/packages/ti-tca9548a/usage.ato
+++ b/packages/ti-tca9548a/usage.ato
@@ -3,7 +3,7 @@
 import ElectricPower
 import I2C
 
-from "ti-tca9548a.ato" import TI_TCA9548A
+from "atopile/ti-tca9548a/ti-tca9548a.ato" import TI_TCA9548A
 
 module Usage:
     """

--- a/packages/ti-tlv75901/README.md
+++ b/packages/ti-tlv75901/README.md
@@ -5,24 +5,21 @@ TLV75901 LDO Regulator with adjustable output voltage
 ## Usage
 
 ```ato
-
+#pragma experiment("BRIDGE_CONNECT")
 import ElectricPower
-
 from "atopile/ti-tlv75901/ti-tlv75901.ato" import TLV75901_driver
-from "atopile/buttons/buttons.ato" import ButtonPulldown
-from "atopile/buttons/buttons.ato" import VerticalButton
 
-module Test:
+module Usage:
     # Create LDO
     ldo = new TLV75901_driver
-
-    # Configure voltages
-    ldo.v_in = 5V +/- 1%
-    ldo.v_out = 3.3V +/- 3%
 
     # Create example power interfaces
     power_in = new ElectricPower
     power_out = new ElectricPower
+
+    # Configure voltages
+    power_in.voltage = 5V +/- 1%
+    power_out.voltage = 3.3V +/- 3%
 
     # Connect to regulator (bridge connect)
     power_in ~> ldo ~> power_out
@@ -30,12 +27,6 @@ module Test:
     # Connect to regulator (Interfaces)
     power_in ~ ldo.power_in
     power_out ~ ldo.power_out
-
-    # Disable button
-    disable_button = new ButtonPulldown
-    disable_button.button.button -> VerticalButton
-    disable_button.output ~ ldo.enable
-    disable_button.pulldown.resistance = 1kohms +/- 20%
 
 ```
 

--- a/packages/ti-tmp117/README.md
+++ b/packages/ti-tmp117/README.md
@@ -24,8 +24,9 @@ The TMP117 is a high-accuracy, low-power, digital temperature sensor with except
 import I2C
 import ElectricPower
 import Resistor
+import ElectricLogic
 
-from "tmp117.ato" import TI_TMP117
+from "atopile/ti-tmp117/ti-tmp117.ato" import TI_TMP117
 
 module Usage:
     """
@@ -44,22 +45,14 @@ module Usage:
     i2c_bus = new I2C
     i2c_bus ~ temp_sensor.i2c
 
-    # I2C pull-up resistors (required for I2C operation)
-    i2c_pullup_scl = new Resistor
-    i2c_pullup_scl.resistance = 4.7kohm +/- 5%
-    i2c_pullup_scl.package = "0402"
-    power_3v3.hv ~> i2c_pullup_scl ~> i2c_bus.scl.line
-
-    i2c_pullup_sda = new Resistor
-    i2c_pullup_sda.resistance = 4.7kohm +/- 5%
-    i2c_pullup_sda.package = "0402"
-    power_3v3.hv ~> i2c_pullup_sda ~> i2c_bus.sda.line
-
-    # I2C address is 0x48 (ADD0 pin tied to GND in module)
-    assert i2c_bus.address is 0x48
+    # Configure address (Possible addresses: 0x48, 0x49, 0x4A, 0x4B)
+    assert temp_sensor.i2c.address is 0x48
 
     # Alert pin is available for temperature limit notifications
     # Can be connected to microcontroller GPIO for interrupt-driven operation
+    alert_pin = new ElectricLogic
+    alert_pin ~ temp_sensor.alert
+
 ```
 
 ## Hardware Features

--- a/packages/ti-tmp117/usage.ato
+++ b/packages/ti-tmp117/usage.ato
@@ -6,7 +6,7 @@ import ElectricPower
 import Resistor
 import ElectricLogic
 
-from "ti-tmp117.ato" import TI_TMP117
+from "atopile/ti-tmp117/ti-tmp117.ato" import TI_TMP117
 
 module Usage:
     """

--- a/packages/ti-tps54560x/README.md
+++ b/packages/ti-tps54560x/README.md
@@ -3,17 +3,34 @@
 ## Usage
 
 ```ato
-from "atopile/ti-tps54560x/ti-tps54560x.ato" import TPS54560x
+from "atopile/ti-tps54560x/ti-tps54560x.ato" import TI_TPS54560
+import ElectricLogic
+import ElectricPower
 
-// Example usage in your design
-module Test5V:
-    regulator = new TPS54560x
+module Usage:
+    """Example usage of TI TPS54560x Buck Converter"""
+
+    # Power rails
+    power_24v = new ElectricPower
+    power_5v = new ElectricPower
+
+    # Buck converter
+    regulator = new TI_TPS54560
+
+    # Configure input/output voltages
     regulator.v_in = 24V +/- 10%
     regulator.v_out = 5V +/- 5%
 
+    # Connect power
+    power_24v ~ regulator.power_in
+    regulator.power_out ~ power_5v
+
+    # Enable control (tie to input voltage for always-on)
     enable = new ElectricLogic
-    enable.line ~ regulator.power_in.vcc # enable active high
+    enable.line ~ power_24v.hv
+    enable.reference ~ power_24v
     regulator.enable ~ enable
+
 ```
 
 ## License

--- a/packages/ti-tps54560x/usage.ato
+++ b/packages/ti-tps54560x/usage.ato
@@ -1,4 +1,4 @@
-from "ti-tps54560x.ato" import TI_TPS54560
+from "atopile/ti-tps54560x/ti-tps54560x.ato" import TI_TPS54560
 import ElectricLogic
 import ElectricPower
 

--- a/packages/ti-tps63020/README.md
+++ b/packages/ti-tps63020/README.md
@@ -17,26 +17,37 @@ The TPS63020 is a high-efficiency, single-inductor buck-boost converter with 4-A
 ## Usage
 
 ```ato
-import ElectricPower
-from "ti-tps63020.ato" import TPS63020_driver
+#pragma experiment("MODULE_TEMPLATING")
+#pragma experiment("FOR_LOOP")
+#pragma experiment("BRIDGE_CONNECT")
+#pragma experiment("TRAITS")
 
-module MyDesign:
+import ElectricPower
+
+from "atopile/ti-tps63020/ti-tps63020.ato" import TPS63020_driver
+
+module Example:
+    """
+    Example usage of the TPS63020 buck-boost converter
+    """
+
     # Power rails
     power_in = new ElectricPower
     power_3v3 = new ElectricPower
 
-    # Configure input power (e.g., from Li-ion battery)
-    assert power_in.voltage within 3.0V to 4.2V
+    # Configure input power (e.g., from battery)
+    assert power_in.voltage within 2.5V to 5V
 
     # Configure output power
     assert power_3v3.voltage within 3.25V to 3.35V
-    assert power_3v3.max_current within 0A to 2A
+    assert power_3v3.max_current within 0A to 3A
 
     # Create buck-boost converter
     converter = new TPS63020_driver
 
     # Connect power
     power_in ~> converter ~> power_3v3
+
 ```
 
 ## Implementation Details

--- a/packages/ti-tps63020/usage.ato
+++ b/packages/ti-tps63020/usage.ato
@@ -5,7 +5,7 @@
 
 import ElectricPower
 
-from "ti-tps63020.ato" import TPS63020_driver
+from "atopile/ti-tps63020/ti-tps63020.ato" import TPS63020_driver
 
 module Example:
     """

--- a/packages/vishay-vcnl4020/README.md
+++ b/packages/vishay-vcnl4020/README.md
@@ -24,7 +24,7 @@ The VCNL4020 is a fully integrated proximity and ambient light sensor with infra
 import ElectricPower
 import I2C
 
-from "vishay-vcnl4020.ato" import Vishay_VCNL4020
+from "atopile/vishay-vcnl4020/vishay-vcnl4020.ato" import Vishay_VCNL4020
 
 module Usage:
     """
@@ -49,6 +49,7 @@ module Usage:
 
     # Set I2C address (fixed for VCNL4020)
     sensor.i2c.address = 0x13
+
 ```
 
 ## Technical Specifications

--- a/packages/vishay-vcnl4020/usage.ato
+++ b/packages/vishay-vcnl4020/usage.ato
@@ -3,7 +3,7 @@
 import ElectricPower
 import I2C
 
-from "vishay-vcnl4020.ato" import Vishay_VCNL4020
+from "atopile/vishay-vcnl4020/vishay-vcnl4020.ato" import Vishay_VCNL4020
 
 module Usage:
     """

--- a/packages/vishay-vcnl4040/README.md
+++ b/packages/vishay-vcnl4040/README.md
@@ -14,9 +14,13 @@ The VCNL4040 is a handy two-in-one sensor with a proximity sensor that works fro
 ## Usage
 
 ```ato
+#pragma experiment("MODULE_TEMPLATING")
+#pragma experiment("BRIDGE_CONNECT")
+#pragma experiment("FOR_LOOP")
+
 import I2C, ElectricPower, ElectricLogic
 
-from "vishay-vcnl4040.ato" import Vishay_VCNL4040
+from "atopile/vishay-vcnl4040/vishay-vcnl4040.ato" import Vishay_VCNL4040
 
 module Usage:
     """
@@ -40,6 +44,7 @@ module Usage:
     # --- Interrupt connection (optional) ---
     interrupt_line = new ElectricLogic
     interrupt_line ~ sensor.int_pin
+
 ```
 
 ## Technical Specifications

--- a/packages/vishay-vcnl4040/usage.ato
+++ b/packages/vishay-vcnl4040/usage.ato
@@ -4,7 +4,7 @@
 
 import I2C, ElectricPower, ElectricLogic
 
-from "vishay-vcnl4040.ato" import Vishay_VCNL4040
+from "atopile/vishay-vcnl4040/vishay-vcnl4040.ato" import Vishay_VCNL4040
 
 module Usage:
     """

--- a/packages/vishay-vcnl4200/README.md
+++ b/packages/vishay-vcnl4200/README.md
@@ -26,12 +26,12 @@ The VCNL4200 is a high-resolution, long-distance proximity and ambient light sen
 import ElectricPower
 import I2C
 
-from "vishay-vcnl4200.ato" import Vishay_VCNL4200
+from "atopile/vishay-vcnl4200/vishay-vcnl4200.ato" import Vishay_VCNL4200
 
 module Usage:
     """
     Minimal usage example for Vishay VCNL4200 proximity and ambient light sensor.
-    Shows how to connect power supply and I2C bus with configurable address.
+    Shows how to connect power supply and I2C bus.
     """
 
     # Create sensor instance
@@ -49,8 +49,12 @@ module Usage:
     power_3v3 ~ sensor.power
     i2c_bus ~ sensor.i2c
 
-    # Set I2C address (0x51 default with LED_CATHODE to GND)
+    # Set I2C address (fixed for VCNL4200)
     sensor.i2c.address = 0x51
+
+    # LED control is optional - leave unconnected for always-on LED
+    # Connect to microcontroller GPIO to control LED programmatically
+
 ```
 
 ## Technical Specifications

--- a/packages/vishay-vcnl4200/usage.ato
+++ b/packages/vishay-vcnl4200/usage.ato
@@ -4,7 +4,7 @@
 import ElectricPower
 import I2C
 
-from "vishay-vcnl4200.ato" import Vishay_VCNL4200
+from "atopile/vishay-vcnl4200/vishay-vcnl4200.ato" import Vishay_VCNL4200
 
 module Usage:
     """

--- a/packages/vishay-veml7700/README.md
+++ b/packages/vishay-veml7700/README.md
@@ -25,7 +25,7 @@ The VEML7700 is a high accuracy ambient light digital 16-bit resolution sensor i
 import ElectricPower
 import I2C
 
-from "vishay-veml7700.ato" import Vishay_VEML7700
+from "atopile/vishay-veml7700/vishay-veml7700.ato" import Vishay_VEML7700
 
 module Usage:
     """
@@ -49,6 +49,7 @@ module Usage:
 
     # Set I²C address (fixed at 0x10)
     assert light_sensor.i2c.address is 0x10
+
 ```
 
 ## Interface Details

--- a/packages/vishay-veml7700/usage.ato
+++ b/packages/vishay-veml7700/usage.ato
@@ -5,7 +5,7 @@
 import ElectricPower
 import I2C
 
-from "vishay-veml7700.ato" import Vishay_VEML7700
+from "atopile/vishay-veml7700/vishay-veml7700.ato" import Vishay_VEML7700
 
 module Usage:
     """

--- a/packages/worldsemi-ws2812b-2020/README.md
+++ b/packages/worldsemi-ws2812b-2020/README.md
@@ -25,7 +25,9 @@ The WS2812B-2020 is an ultra-compact addressable RGB LED that integrates control
 import ElectricPower
 import ElectricLogic
 
-from "worldsemi-ws2812b-2020.ato" import Worldsemi_WS2812B_2020, WS2812B_2020_HighDensity_Strip, WS2812B_2020_Matrix
+from "atopile/worldsemi-ws2812b-2020/worldsemi-ws2812b-2020.ato" import Worldsemi_WS2812B_2020
+from "atopile/worldsemi-ws2812b-2020/worldsemi-ws2812b-2020.ato" import WS2812B_2020_HighDensity_Strip
+from "atopile/worldsemi-ws2812b-2020/worldsemi-ws2812b-2020.ato" import WS2812B_2020_Matrix
 
 module Usage:
     """
@@ -76,6 +78,7 @@ module Usage:
     """Data signal for 5×5 LED matrix"""
     matrix_data ~ led_matrix.data_in
     power_5v ~ matrix_data.reference
+
 ```
 
 ## Technical Specifications

--- a/packages/worldsemi-ws2812b-2020/usage.ato
+++ b/packages/worldsemi-ws2812b-2020/usage.ato
@@ -5,9 +5,9 @@
 import ElectricPower
 import ElectricLogic
 
-from "worldsemi-ws2812b-2020.ato" import Worldsemi_WS2812B_2020
-from "worldsemi-ws2812b-2020.ato" import WS2812B_2020_HighDensity_Strip
-from "worldsemi-ws2812b-2020.ato" import WS2812B_2020_Matrix
+from "atopile/worldsemi-ws2812b-2020/worldsemi-ws2812b-2020.ato" import Worldsemi_WS2812B_2020
+from "atopile/worldsemi-ws2812b-2020/worldsemi-ws2812b-2020.ato" import WS2812B_2020_HighDensity_Strip
+from "atopile/worldsemi-ws2812b-2020/worldsemi-ws2812b-2020.ato" import WS2812B_2020_Matrix
 
 module Usage:
     """

--- a/packages/worldsemi-ws2812c-5050/README.md
+++ b/packages/worldsemi-ws2812c-5050/README.md
@@ -17,14 +17,16 @@ The WS2812C is an intelligent control LED integrated light source that incorpora
 ## Usage
 
 ```ato
-#pragma experiment("TRAITS")
 #pragma experiment("FOR_LOOP")
 #pragma experiment("BRIDGE_CONNECT")
+#pragma experiment("TRAITS")
 
 import ElectricPower
 import ElectricLogic
 
-from "worldsemi-ws2812c.ato" import Worldsemi_WS2812C, WS2812C_Strip
+from "atopile/worldsemi-ws2812c-5050/worldsemi-ws2812c.ato" import Worldsemi_WS2812C
+from "atopile/worldsemi-ws2812c-5050/worldsemi-ws2812c.ato" import WS2812C_Strip
+from "atopile/worldsemi-ws2812c-5050/worldsemi-ws2812c.ato" import WS2812C_Matrix
 
 module Usage:
     """
@@ -34,7 +36,7 @@ module Usage:
     - Single LED configuration
     - LED strip with multiple LEDs
     - Proper power supply and data connections
-    - Power filtering for stable operation
+    - Matrix example
     """
 
     # --- Single LED Example ---
@@ -61,20 +63,13 @@ module Usage:
     strip_data = new ElectricLogic
     """Data signal for LED strip"""
     strip_data ~ led_strip.data_in
-    power_5v ~ strip_data.reference
 
-    # --- Alternative: Manual LED Chain ---
-    manual_leds = new Worldsemi_WS2812C[5]
+    # Matrix
+    led_matrix = new WS2812C_Matrix
 
-    # Connect power to all LEDs
-    for led in manual_leds:
-        power_5v ~ led.power
+    # Connect power to matrix
+    power_5v ~ led_matrix.power
 
-    # Chain data manually
-    chain_data = new ElectricLogic
-    """Manual chaining data input"""
-    power_5v ~ chain_data.reference
-    chain_data ~> manual_leds[0] ~> manual_leds[1] ~> manual_leds[2] ~> manual_leds[3] ~> manual_leds[4]
 ```
 
 ## Technical Specifications

--- a/packages/worldsemi-ws2812c-5050/usage.ato
+++ b/packages/worldsemi-ws2812c-5050/usage.ato
@@ -5,9 +5,9 @@
 import ElectricPower
 import ElectricLogic
 
-from "worldsemi-ws2812c.ato" import Worldsemi_WS2812C
-from "worldsemi-ws2812c.ato" import WS2812C_Strip
-from "worldsemi-ws2812c.ato" import WS2812C_Matrix
+from "atopile/worldsemi-ws2812c-5050/worldsemi-ws2812c.ato" import Worldsemi_WS2812C
+from "atopile/worldsemi-ws2812c-5050/worldsemi-ws2812c.ato" import WS2812C_Strip
+from "atopile/worldsemi-ws2812c-5050/worldsemi-ws2812c.ato" import WS2812C_Matrix
 
 module Usage:
     """

--- a/packages/xt-connectors/README.md
+++ b/packages/xt-connectors/README.md
@@ -25,6 +25,7 @@ module Usage:
     power ~ vertical_male.power
     power ~ right_angle_female.power
     power ~ vertical_female.power
+
 ```
 
 ## Contributing

--- a/scripts/check_status.py
+++ b/scripts/check_status.py
@@ -1,0 +1,260 @@
+#! uv run
+# /// script
+# dependencies = [
+#   "typer>=0.12",
+#   "typing_extensions>=4.10.0",
+#   "rich>=13.0.0",
+#   "pandas>=2.0.0",
+# ]
+# ///
+
+import re
+import time
+import subprocess
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+import typer
+from rich.console import Console, Group
+from rich.table import Table
+from rich.live import Live
+
+app = typer.Typer()
+
+console = Console()
+
+
+def build_and_verify(
+    package_dir: Path, args: tuple
+) -> tuple[
+    str,
+    bool,
+    bool,
+    float,
+    int,
+    str,
+    str,
+    int | None,
+    str | None,
+    str | None,
+]:
+    """
+    Runs 'ato build --keep-picked-parts' then 'ato package verify' for a package.
+    Returns: (package_name, build_success, verify_success, build_seconds)
+    """
+    package_name = package_dir.name
+
+    # Build
+    build_start = time.perf_counter()
+    build_proc = subprocess.run(
+        ["ato", "build", "--frozen"] + list(args),
+        cwd=package_dir,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    build_success = build_proc.returncode == 0
+    build_seconds = max(0.0, time.perf_counter() - build_start)
+
+    # Verify (only if build ok)
+    verify_success = False
+    verify_rc: int | None = None
+    verify_stdout: str | None = None
+    verify_stderr: str | None = None
+    if build_success:
+        verify_proc = subprocess.run(
+            ["ato", "package", "verify"],
+            cwd=package_dir,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        verify_rc = verify_proc.returncode
+        verify_stdout = verify_proc.stdout
+        verify_stderr = verify_proc.stderr
+        verify_success = verify_rc == 0
+
+    return (
+        package_name,
+        build_success,
+        verify_success,
+        build_seconds,
+        build_proc.returncode,
+        build_proc.stdout,
+        build_proc.stderr,
+        verify_rc,
+        verify_stdout,
+        verify_stderr,
+    )
+
+
+@app.command()
+def main(
+    args: list[str] = typer.Argument(None, help="Arguments to pass to ato build"),
+    package_regex: str = typer.Option(None, help="Regex to filter packages to build"),
+):
+    """Builds and verifies all packages in the 'packages' directory in parallel."""
+    original_dir = Path.cwd()
+    packages_dir = Path("packages")
+
+    if not packages_dir.is_dir():
+        console.print(
+            f"[red]❌ Error: 'packages' directory not found in {original_dir}[/red]"
+        )
+        return
+
+    package_subdirs = [d for d in packages_dir.iterdir() if d.is_dir()]
+
+    if not package_subdirs:
+        console.print(f"[yellow]No packages found in {packages_dir}[/yellow]")
+        return
+
+    if package_regex:
+        package_subdirs = [
+            d for d in package_subdirs if re.match(package_regex, d.name)
+        ]
+
+    build_args = tuple(args) if args else ()
+
+    # Accumulator for results and DataFrame
+    results_rows: list[dict] = []
+
+    def make_summary_tables() -> Group:
+        # Totals
+        build_fail = sum(1 for r in results_rows if r["build_success"] is False)
+        verify_fail = sum(
+            1 for r in results_rows if r["build_success"] and not r["verify_success"]
+        )
+        pass_both = sum(
+            1 for r in results_rows if r["build_success"] and r["verify_success"]
+        )
+
+        # Top summary table with counts in headers
+        summary = Table(show_header=True, header_style="bold magenta")
+        summary.add_column(f"Fails Build ({build_fail})", justify="center")
+        summary.add_column(f"Fails Verify ({verify_fail})", justify="center")
+        summary.add_column(f"Passes Both ({pass_both})", justify="center")
+        summary.add_row(
+            f"[red]{build_fail}[/red]",
+            f"[yellow]{verify_fail}[/yellow]",
+            f"[green]{pass_both}[/green]",
+        )
+
+        # Detailed per-package table
+        detail = Table(show_header=True, header_style="bold cyan")
+        detail.add_column("Package", overflow="fold")
+        detail.add_column("Build", justify="center")
+        detail.add_column("Verify", justify="center")
+        detail.add_column("Build Time (s)", justify="right")
+
+        # Sort by build time (descending: slowest first)
+        for r in sorted(results_rows, key=lambda x: x["build_seconds"], reverse=True):
+            build_cell = (
+                "[green]PASS[/green]" if r["build_success"] else "[red]FAIL[/red]"
+            )
+            if not r["build_success"]:
+                verify_cell = "[dim]-[/dim]"
+            else:
+                verify_cell = (
+                    "[green]PASS[/green]" if r["verify_success"] else "[red]FAIL[/red]"
+                )
+            detail.add_row(
+                r["package_name"],
+                build_cell,
+                verify_cell,
+                f"{r['build_seconds']:.1f}",
+            )
+
+        return Group(summary, detail)
+
+    with Live(console=console, refresh_per_second=8) as live:
+        with ProcessPoolExecutor() as executor:
+            futures = {
+                executor.submit(build_and_verify, subdir, build_args): subdir
+                for subdir in package_subdirs
+            }
+            for future in as_completed(futures):
+                (
+                    package_name,
+                    build_ok,
+                    verify_ok,
+                    build_secs,
+                    build_rc,
+                    build_out,
+                    build_err,
+                    verify_rc,
+                    verify_out,
+                    verify_err,
+                ) = future.result()
+                results_rows.append(
+                    {
+                        "package_name": package_name,
+                        "build_success": build_ok,
+                        "verify_success": verify_ok,
+                        "build_seconds": build_secs,
+                        "build_rc": build_rc,
+                        "build_stdout": build_out,
+                        "build_stderr": build_err,
+                        "verify_rc": verify_rc,
+                        "verify_stdout": verify_out,
+                        "verify_stderr": verify_err,
+                    }
+                )
+                # Update live tables
+                live.update(make_summary_tables())
+
+    # Construct DataFrame (optional) and save to CSV if pandas is available
+    try:
+        pd = __import__("pandas")
+        df = pd.DataFrame(
+            results_rows,
+            columns=[
+                "package_name",
+                "build_success",
+                "verify_success",
+                "build_seconds",
+            ],
+        )
+        out_csv = Path("build_status.csv")
+        df.to_csv(out_csv, index=False)
+        console.print(f"[dim]Saved build status to {out_csv.resolve()}[/dim]")
+    except Exception:
+        console.print(
+            "[yellow]pandas not available; skipping DataFrame export[/yellow]"
+        )
+
+    # Exit with non-zero if any failed build or failed verify; print detailed logs
+    any_failed = any(
+        (not r["build_success"]) or (r["build_success"] and not r["verify_success"])
+        for r in results_rows
+    )
+    if any_failed:
+        console.rule("[bold red]Failure Details")
+        for r in sorted(results_rows, key=lambda x: x["package_name"].lower()):
+            if not r["build_success"]:
+                console.print(
+                    f"[red]❌ {r['package_name']} – Build failed (rc={r.get('build_rc')})[/red]"
+                )
+                if r.get("build_stderr"):
+                    console.print("[bold]stderr:[/bold]")
+                    console.print(r["build_stderr"])
+                if r.get("build_stdout"):
+                    console.print("[bold]stdout:[/bold]")
+                    console.print(r["build_stdout"])
+                console.print()
+                continue
+            if r["build_success"] and not r["verify_success"]:
+                console.print(
+                    f"[yellow]⚠️ {r['package_name']} – Verify failed (rc={r.get('verify_rc')})[/yellow]"
+                )
+                if r.get("verify_stderr"):
+                    console.print("[bold]stderr:[/bold]")
+                    console.print(r["verify_stderr"])
+                if r.get("verify_stdout"):
+                    console.print("[bold]stdout:[/bold]")
+                    console.print(r["verify_stdout"])
+                console.print()
+        raise typer.Exit(code=1)
+
+
+if __name__ == "__main__":
+    app()

--- a/scripts/check_status.py
+++ b/scripts/check_status.py
@@ -46,7 +46,7 @@ def build_and_verify(
     # Build
     build_start = time.perf_counter()
     build_proc = subprocess.run(
-        ["ato", "build", "--frozen"] + list(args),
+        ["ato", "build", "--keep-picked-parts"] + list(args),
         cwd=package_dir,
         capture_output=True,
         text=True,


### PR DESCRIPTION
Most packages have local imports instead of importing from "atopile/*" in usage.ato.

Going through all packages and changing the usage imports. Also changing the corresponding Readme.md to match this change.

Not incrementing package version for this change. Will have LLM iterate through each package and clear up individual nonconformities and uprev for release.