### PR TITLE
Update maxim-ds3502 package to atopile 0.11.6

### DIFF
--- a/packages/maxim-ds3502/README.md
+++ b/packages/maxim-ds3502/README.md
@@ -29,47 +29,31 @@ This package wraps the raw IC in a reusable Ato **module** that exposes:
 ```ato
 import ElectricPower
 import I2C
-import Electrical
 
 from "atopile/maxim-ds3502/maxim-ds3502.ato" import Maxim_DS3502
-
-# Example MCU providing I²C bus and reading the wiper voltage with an ADC pin
-module MCU:
-    power = new ElectricPower
-    i2c = new I2C
-    adc_in = new Electrical
 
 module Usage:
     """
     Minimal wiring for the Maxim DS3502 (10 kΩ) used as a programmable voltage divider.
 
     1. The potentiometer top end (`RH`) is tied to 3V3, bottom end (`RL`) to GND.
-    2. The wiper (`RW`) is routed to an MCU ADC input so firmware can read the
+    2. The wiper (`RW`) can be routed to an MCU ADC input so firmware can read the
        divided voltage and the DS3502 can trim it over I²C.
     3. Address pins `A1:A0` are left low which selects I²C address 0x28.
     """
 
-    # MCU with I²C and ADC capabilities
-    mcu = new MCU
-
-    # Shared 3 V3 rail
-    power_3v3 = new ElectricPower
-    power_3v3.voltage = 3.3V +/- 5%
-
-    # I²C bus (Fast-mode, 400 kHz)
-    i2c_bus = new I2C
-    i2c_bus.address = 0x28  # A1=A0=0 on DS3502
-
-    # DS3502 instance
+    # DS3502 digital potentiometer
     pot = new Maxim_DS3502
 
-    # Power distribution
-    power_3v3 ~ mcu.power
-    power_3v3 ~ pot.power
+    # Power supply (3.3V typical)
+    power = new ElectricPower
+    assert power.voltage within 3.3V +/- 5%
+    power ~ pot.power
 
-    # Connect I²C
-    i2c_bus ~ mcu.i2c
-    i2c_bus ~ pot.i2c
+    # I²C bus (would connect to your MCU)
+    i2c = new I2C
+    i2c.address = 0x28  # A1=A0=0 on DS3502
+    i2c ~ pot.i2c
 
 ```
 

--- a/packages/maxim-ds3502/ato.yaml
+++ b/packages/maxim-ds3502/ato.yaml
@@ -1,4 +1,4 @@
-requires-atopile: "^0.10.8"
+requires-atopile: "^0.11.6"
 
 paths:
   src: ./
@@ -18,7 +18,7 @@ package:
   identifier: atopile/maxim-ds3502
   repository: https://github.com/atopile/packages
   homepage: https://github.com/atopile/packages/blob/main/packages/maxim-ds3502/README.md
-  version: "0.1.0"
+  version: "0.1.1"
   authors:
     - name: atopile
       email: hi@atopile.io

--- a/packages/maxim-ds3502/layouts/default/default.kicad_pcb
+++ b/packages/maxim-ds3502/layouts/default/default.kicad_pcb
@@ -89,14 +89,14 @@
     (net 0 "")
     (net 1 "RH")
     (net 2 "SDA")
-    (net 3 "A0")
-    (net 4 "Vpos")
+    (net 3 "address_bit_0")
+    (net 4 "_wiper_bias-VCC")
     (net 5 "RW")
     (net 6 "RL")
-    (net 7 "A1")
+    (net 7 "address_bit_1")
     (net 8 "SCL")
-    (net 9 "gnd")
-    (net 10 "hv")
+    (net 9 "GND")
+    (net 10 "power-VCC")
     (footprint "UNI_ROYAL_0402WGF4701TCE:R0402"
         (layer "F.Cu")
         (uuid "7f41b212-0ec0-41b3-8b48-562f4642524b")
@@ -105,7 +105,7 @@
             (at 0 -4 0)
             (layer "F.SilkS")
             (hide yes)
-            (uuid "ad284745-9833-42b3-8cc0-c68af5d9bcdf")
+            (uuid "c93e4c64-f84f-4e03-9a45-25a8f9965aa5")
             (effects
                 (font
                     (size 1 1)
@@ -117,7 +117,7 @@
             (at 0 4 0)
             (layer "F.Fab")
             (hide no)
-            (uuid "d974e539-e7dd-4765-a570-7bbdb0e66bb5")
+            (uuid "5c6dc7bf-ced8-4d2e-8d14-1e3dde8315fa")
             (effects
                 (font
                     (size 1 1)
@@ -153,7 +153,7 @@
             (at 0 0 0)
             (layer "User.9")
             (hide no)
-            (uuid "a2376b8b-547e-48b3-a361-a2658db62fdf")
+            (uuid "f06d41c2-23e8-498c-bf32-1101afc66fc9")
             (effects
                 (font
                     (size 0.125 0.125)
@@ -162,11 +162,11 @@
                 (hide yes)
             )
         )
-        (property "__atopile_lib_fp_hash__" "f92c29e2-6901-2273-8c64-0d6fc82f7c3a"
+        (property "__atopile_lib_fp_hash__" "66a6df7a-35db-d48c-1b44-17c6253711c4"
             (at 0 0 0)
             (layer "User.9")
             (hide yes)
-            (uuid "3f84a3ce-600e-469d-ae7d-096b4642524b")
+            (uuid "06e3f996-e9a3-405b-98d7-0bab4642524b")
             (effects
                 (font
                     (size 0.125 0.125)
@@ -267,7 +267,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "5befe651-52a8-4c8b-9bfc-b0ab1edff76a")
+            (uuid "be005586-56f1-4209-92be-84195bf4394f")
         )
         (fp_line
             (start -0.94 0.5)
@@ -277,7 +277,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "7abb75bd-2be3-437d-b292-38d11cb8398b")
+            (uuid "82f9b388-d606-4124-a8d4-5603c7c3f6c7")
         )
         (fp_line
             (start -0.94 -0.5)
@@ -287,7 +287,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "1b9d747c-9c47-492f-a404-8a52f180379d")
+            (uuid "3575d6e5-ed5a-43a9-9bc6-9385da1e64f5")
         )
         (fp_line
             (start 0.23 0.5)
@@ -297,7 +297,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "d825b4d7-de00-4ecf-9ff9-751b9aaa6aa9")
+            (uuid "c87d7556-597e-4f5e-964a-24d1efa25d69")
         )
         (fp_line
             (start 0.94 0.5)
@@ -307,7 +307,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "c4ebbb1f-1a69-48ac-a86c-44d30310c8a7")
+            (uuid "345b711c-48b6-4f80-8822-8cfbd1c77b61")
         )
         (fp_line
             (start 0.94 -0.5)
@@ -317,7 +317,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "d4cc2a9a-d2f6-4017-ac78-efaee4f9be54")
+            (uuid "50be0952-01be-44af-80f1-d4bbbf52dd80")
         )
         (fp_circle
             (center -0.5 0.25)
@@ -328,12 +328,12 @@
             )
             (fill no)
             (layer "F.Fab")
-            (uuid "3515a81f-9a9e-4b67-b6c4-0b80b0565bfb")
+            (uuid "9bdc7b50-73ab-44fb-9cee-547ffd8f532c")
         )
         (fp_text user "%R"
             (at 0 0 0)
             (layer "F.Fab")
-            (uuid "76f67181-80f0-466f-aa38-806898fc7679")
+            (uuid "0cdd0574-28dd-44fb-bc4e-b660e9e44d74")
             (effects
                 (font
                     (size 1 1)
@@ -345,7 +345,7 @@
         (fp_text user "${REFERENCE}"
             (at 0 -4 0)
             (layer "F.SilkS")
-            (uuid "ad284745-9833-42b3-8cc0-c68af5d9bcdf")
+            (uuid "c93e4c64-f84f-4e03-9a45-25a8f9965aa5")
             (effects
                 (font
                     (size 1 1)
@@ -359,15 +359,15 @@
             (at 0.43 0 -90)
             (size 0.57 0.54)
             (layers "F.Cu" "F.Paste" "F.Mask")
-            (net 10 "hv")
-            (uuid "199e29a8-7c4b-47c7-8168-5f4cd81c33a8")
+            (net 10 "power-VCC")
+            (uuid "fdf46de2-1ee2-4a0a-be6b-919a81618593")
         )
         (pad "1" smd rect
             (at -0.43 0 -90)
             (size 0.57 0.54)
             (layers "F.Cu" "F.Paste" "F.Mask")
             (net 8 "SCL")
-            (uuid "9100c6c8-154a-4949-9b6a-230cdc0a9d8d")
+            (uuid "b5674ebe-8491-4a36-b544-83fba3091727")
         )
         (model "${KIPRJMOD}/../../parts/UNI_ROYAL_0402WGF4701TCE/R0402_L1.0-W0.5-H0.4.step"
             (offset
@@ -389,7 +389,7 @@
             (at 0 -4 0)
             (layer "F.SilkS")
             (hide yes)
-            (uuid "ad284745-9833-42b3-8cc0-c68af5d9bcdf")
+            (uuid "c93e4c64-f84f-4e03-9a45-25a8f9965aa5")
             (effects
                 (font
                     (size 1 1)
@@ -401,7 +401,7 @@
             (at 0 4 0)
             (layer "F.Fab")
             (hide no)
-            (uuid "d974e539-e7dd-4765-a570-7bbdb0e66bb5")
+            (uuid "5c6dc7bf-ced8-4d2e-8d14-1e3dde8315fa")
             (effects
                 (font
                     (size 1 1)
@@ -437,7 +437,7 @@
             (at 0 0 0)
             (layer "User.9")
             (hide no)
-            (uuid "a2376b8b-547e-48b3-a361-a2658db62fdf")
+            (uuid "f06d41c2-23e8-498c-bf32-1101afc66fc9")
             (effects
                 (font
                     (size 0.125 0.125)
@@ -446,11 +446,11 @@
                 (hide yes)
             )
         )
-        (property "__atopile_lib_fp_hash__" "f92c29e2-6901-2273-8c64-0d6fc82f7c3a"
+        (property "__atopile_lib_fp_hash__" "66a6df7a-35db-d48c-1b44-17c6253711c4"
             (at 0 0 0)
             (layer "User.9")
             (hide yes)
-            (uuid "c4abbca5-5ab5-4c67-bea2-91984642524b")
+            (uuid "9c1da26d-d91e-45d0-8787-50424642524b")
             (effects
                 (font
                     (size 0.125 0.125)
@@ -551,7 +551,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "5befe651-52a8-4c8b-9bfc-b0ab1edff76a")
+            (uuid "be005586-56f1-4209-92be-84195bf4394f")
         )
         (fp_line
             (start -0.94 0.5)
@@ -561,7 +561,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "7abb75bd-2be3-437d-b292-38d11cb8398b")
+            (uuid "82f9b388-d606-4124-a8d4-5603c7c3f6c7")
         )
         (fp_line
             (start -0.94 -0.5)
@@ -571,7 +571,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "1b9d747c-9c47-492f-a404-8a52f180379d")
+            (uuid "3575d6e5-ed5a-43a9-9bc6-9385da1e64f5")
         )
         (fp_line
             (start 0.23 0.5)
@@ -581,7 +581,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "d825b4d7-de00-4ecf-9ff9-751b9aaa6aa9")
+            (uuid "c87d7556-597e-4f5e-964a-24d1efa25d69")
         )
         (fp_line
             (start 0.94 0.5)
@@ -591,7 +591,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "c4ebbb1f-1a69-48ac-a86c-44d30310c8a7")
+            (uuid "345b711c-48b6-4f80-8822-8cfbd1c77b61")
         )
         (fp_line
             (start 0.94 -0.5)
@@ -601,7 +601,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "d4cc2a9a-d2f6-4017-ac78-efaee4f9be54")
+            (uuid "50be0952-01be-44af-80f1-d4bbbf52dd80")
         )
         (fp_circle
             (center -0.5 0.25)
@@ -612,12 +612,12 @@
             )
             (fill no)
             (layer "F.Fab")
-            (uuid "3515a81f-9a9e-4b67-b6c4-0b80b0565bfb")
+            (uuid "9bdc7b50-73ab-44fb-9cee-547ffd8f532c")
         )
         (fp_text user "%R"
             (at 0 0 0)
             (layer "F.Fab")
-            (uuid "76f67181-80f0-466f-aa38-806898fc7679")
+            (uuid "0cdd0574-28dd-44fb-bc4e-b660e9e44d74")
             (effects
                 (font
                     (size 1 1)
@@ -629,7 +629,7 @@
         (fp_text user "${REFERENCE}"
             (at 0 -4 0)
             (layer "F.SilkS")
-            (uuid "ad284745-9833-42b3-8cc0-c68af5d9bcdf")
+            (uuid "c93e4c64-f84f-4e03-9a45-25a8f9965aa5")
             (effects
                 (font
                     (size 1 1)
@@ -643,15 +643,15 @@
             (at 0.43 0 -90)
             (size 0.57 0.54)
             (layers "F.Cu" "F.Paste" "F.Mask")
-            (net 10 "hv")
-            (uuid "199e29a8-7c4b-47c7-8168-5f4cd81c33a8")
+            (net 10 "power-VCC")
+            (uuid "fdf46de2-1ee2-4a0a-be6b-919a81618593")
         )
         (pad "1" smd rect
             (at -0.43 0 -90)
             (size 0.57 0.54)
             (layers "F.Cu" "F.Paste" "F.Mask")
             (net 2 "SDA")
-            (uuid "9100c6c8-154a-4949-9b6a-230cdc0a9d8d")
+            (uuid "b5674ebe-8491-4a36-b544-83fba3091727")
         )
         (model "${KIPRJMOD}/../../parts/UNI_ROYAL_0402WGF4701TCE/R0402_L1.0-W0.5-H0.4.step"
             (offset
@@ -673,7 +673,7 @@
             (at 0 -4 0)
             (layer "F.SilkS")
             (hide yes)
-            (uuid "5e177789-2837-437e-8257-1916b8e6c0dc")
+            (uuid "cb4fbbfd-b4ec-44f5-8611-fe7814d3e386")
             (effects
                 (font
                     (size 1 1)
@@ -685,7 +685,7 @@
             (at 0 4 0)
             (layer "F.Fab")
             (hide no)
-            (uuid "1975453c-41cd-43e4-b285-9bd82ed47cf3")
+            (uuid "0f7b39bd-edda-4a60-8aa3-1a828bc8aebe")
             (effects
                 (font
                     (size 1 1)
@@ -721,7 +721,7 @@
             (at 0 0 0)
             (layer "User.9")
             (hide no)
-            (uuid "5a5cc632-4266-4ab7-acb3-aa0b5ced6429")
+            (uuid "179c408f-6235-486d-a1b3-8725ede7f89a")
             (effects
                 (font
                     (size 0.125 0.125)
@@ -730,11 +730,11 @@
                 (hide yes)
             )
         )
-        (property "__atopile_lib_fp_hash__" "f8cfc16c-2d15-25d8-bcf0-af889ed0beb7"
+        (property "__atopile_lib_fp_hash__" "abd85f6b-95fa-ed5a-88fe-be39d3a76574"
             (at 0 0 0)
             (layer "User.9")
             (hide yes)
-            (uuid "73fdf6da-f92c-4657-af7f-53724642524b")
+            (uuid "f32e39fe-124e-43ef-91f7-60e04642524b")
             (effects
                 (font
                     (size 0.125 0.125)
@@ -835,7 +835,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "6df3d865-6925-4a87-91e0-e2fa9d86d1e9")
+            (uuid "623226e1-f11e-4267-bfac-71c433a52cc8")
         )
         (fp_line
             (start 0.23 0.5)
@@ -845,7 +845,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "1f764452-8f3e-4a06-8bf3-231cde5820a9")
+            (uuid "8cf5ccaf-11ed-4407-a114-a53eca8621f3")
         )
         (fp_line
             (start 1.17 0.35)
@@ -855,7 +855,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "675a029f-688e-4551-9ac6-b20831028752")
+            (uuid "0cd6722a-2e99-445a-96aa-c3aeb88d2622")
         )
         (fp_line
             (start -1.02 -0.5)
@@ -865,7 +865,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "1c1fe559-c8a2-4fca-9702-5261c0857ddc")
+            (uuid "4ca2b9ee-3fab-4d8b-8519-5d00b34e35bf")
         )
         (fp_line
             (start -0.23 0.5)
@@ -875,7 +875,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "45a754a9-ab3a-474c-8458-5682120ca908")
+            (uuid "683133b9-0809-45eb-9a6f-8d8ca75d12d7")
         )
         (fp_line
             (start -1.17 0.35)
@@ -885,7 +885,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "35ef18a2-a449-4935-a6c0-02607ab431e9")
+            (uuid "0d8bfb30-430e-49f5-b63c-26e9cd5f317c")
         )
         (fp_arc
             (start 1.17 0.35)
@@ -896,7 +896,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "bf9b4495-0b7d-48bf-96a5-42ab918b1702")
+            (uuid "75f68864-4668-4460-89b2-237577480af1")
         )
         (fp_arc
             (start 1.02 -0.5)
@@ -907,7 +907,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "4413cb63-cd6c-4e58-91dc-0c4bb5e481f2")
+            (uuid "fdd6bfb0-c576-4f83-9779-0b9065a71285")
         )
         (fp_arc
             (start -1.17 0.35)
@@ -918,7 +918,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "68322da5-760e-477b-9e32-04b7189198c6")
+            (uuid "5b021e40-c54f-41d9-b4d5-16d2e0b32419")
         )
         (fp_arc
             (start -1.02 -0.5)
@@ -929,7 +929,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "be848dc7-9690-4aaa-b89b-97688c338439")
+            (uuid "680a4095-09ec-4aaf-aa4b-a3a3c3fd1941")
         )
         (fp_circle
             (center -0.5 0.25)
@@ -940,12 +940,12 @@
             )
             (fill no)
             (layer "F.Fab")
-            (uuid "0f4dba9d-e19b-4e04-9043-031ca93a8c07")
+            (uuid "30315650-4766-480e-b600-111bad2e2cb1")
         )
         (fp_text user "%R"
             (at 0 0 0)
             (layer "F.Fab")
-            (uuid "4c2d32f2-e3af-46e4-bcae-68cb9044daed")
+            (uuid "d1f18b3c-2dc6-4029-b037-7fbbab090a99")
             (effects
                 (font
                     (size 1 1)
@@ -957,7 +957,7 @@
         (fp_text user "${REFERENCE}"
             (at 0 -4 0)
             (layer "F.SilkS")
-            (uuid "5e177789-2837-437e-8257-1916b8e6c0dc")
+            (uuid "cb4fbbfd-b4ec-44f5-8611-fe7814d3e386")
             (effects
                 (font
                     (size 1 1)
@@ -971,15 +971,15 @@
             (at 0.55 0 -90)
             (size 0.79 0.54)
             (layers "F.Cu" "F.Paste" "F.Mask")
-            (net 9 "gnd")
-            (uuid "c96cc429-398b-4b3d-8a36-e1656f3d1c29")
+            (net 9 "GND")
+            (uuid "f443ec50-760f-410d-80c7-c0631c312cf2")
         )
         (pad "1" smd rect
             (at -0.55 0 -90)
             (size 0.79 0.54)
             (layers "F.Cu" "F.Paste" "F.Mask")
-            (net 10 "hv")
-            (uuid "141ecb78-15fc-43f7-83a0-032c852990f8")
+            (net 10 "power-VCC")
+            (uuid "a25d49bc-c3c4-408f-9aa0-d394ef8121a3")
         )
         (model "${KIPRJMOD}/../../parts/Samsung_Electro_Mechanics_CL05B104KO5NNNC/C0402_L1.0-W0.5-H0.5.step"
             (offset
@@ -1048,20 +1048,21 @@
         (property "checksum" "4c74edf4b82d05aba1ec889a3eda19af01524de14752a39757003aefc72fb346"
             (at 0 0 0)
             (layer "User.9")
-            (hide yes)
+            (hide no)
             (uuid "0de809c2-4b49-4ba3-aa01-35d4d0352b67")
             (effects
                 (font
                     (size 0.125 0.125)
                     (thickness 0.01875)
                 )
+                (hide yes)
             )
         )
-        (property "__atopile_lib_fp_hash__" "5a65c929-18de-debf-e420-aa36680425bf"
+        (property "__atopile_lib_fp_hash__" "76953ce2-ce42-346e-26a4-3cca14fbd08e"
             (at 0 0 0)
             (layer "User.9")
             (hide yes)
-            (uuid "c97d6ed8-e1af-43ea-93fd-b6d84642524b")
+            (uuid "7f196cb8-fd43-4f20-a39d-20eb4642524b")
             (effects
                 (font
                     (size 0.125 0.125)
@@ -1119,16 +1120,6 @@
         )
         (attr smd)
         (fp_line
-            (start -1.5 -1.5)
-            (end -1.5 -0.5)
-            (stroke
-                (width 0.25)
-                (type solid)
-            )
-            (layer "F.SilkS")
-            (uuid "6c8e7395-3461-4b72-82f0-4019667c8c83")
-        )
-        (fp_line
             (start -1.5 1.5)
             (end -1.5 0.5)
             (stroke
@@ -1137,16 +1128,6 @@
             )
             (layer "F.SilkS")
             (uuid "6cb8d312-1812-4dce-9973-5498dc6e1bd6")
-        )
-        (fp_line
-            (start -1.5 1.5)
-            (end 1.5 1.5)
-            (stroke
-                (width 0.25)
-                (type solid)
-            )
-            (layer "F.SilkS")
-            (uuid "dea3b296-0325-489f-a054-d8e543ede702")
         )
         (fp_line
             (start 1.5 -1.5)
@@ -1168,27 +1149,36 @@
             (layer "F.SilkS")
             (uuid "e770ddfd-4549-4c7b-9d12-809769d4cc32")
         )
+        (fp_line
+            (start -1.5 1.5)
+            (end 1.5 1.5)
+            (stroke
+                (width 0.25)
+                (type solid)
+            )
+            (layer "F.SilkS")
+            (uuid "dea3b296-0325-489f-a054-d8e543ede702")
+        )
+        (fp_line
+            (start -1.5 -1.5)
+            (end -1.5 -0.5)
+            (stroke
+                (width 0.25)
+                (type solid)
+            )
+            (layer "F.SilkS")
+            (uuid "6c8e7395-3461-4b72-82f0-4019667c8c83")
+        )
         (fp_arc
-            (start -1.508726 0.499924)
-            (mid -1.495655 -0.499981)
-            (end -1.5 0.5)
+            (start -1.5 0.5)
+            (mid -1.495636732250813 -0.49998096153208565)
+            (end -1.5087262032186417 0.49992384757819563)
             (stroke
                 (width 0.25)
                 (type solid)
             )
             (layer "F.SilkS")
             (uuid "aed70457-ecd6-409c-affb-007db905b95d")
-        )
-        (fp_circle
-            (center -1.1 2.3)
-            (end -0.98 2.3)
-            (stroke
-                (width 0.25)
-                (type solid)
-            )
-            (fill no)
-            (layer "Cmts.User")
-            (uuid "55485294-0965-419a-8ec1-2b9460cfc60c")
         )
         (fp_circle
             (center -1.5 2.45)
@@ -1201,77 +1191,112 @@
             (layer "F.Fab")
             (uuid "b8e020b0-f789-426c-a72c-ae3533a8bead")
         )
-        (pad "1" smd rect
-            (at -1 2.3 180)
-            (size 0.3 1)
-            (layers "F.Cu" "F.Mask" "F.Paste")
-            (net 2 "SDA")
-            (uuid "9f51ee0d-14b0-4bfa-af5f-b8259c072cf3")
+        (fp_circle
+            (center -1.1 2.3)
+            (end -0.98 2.3)
+            (stroke
+                (width 0.25)
+                (type solid)
+            )
+            (fill no)
+            (layer "Cmts.User")
+            (uuid "55485294-0965-419a-8ec1-2b9460cfc60c")
         )
-        (pad "2" smd rect
-            (at -0.5 2.3 180)
-            (size 0.3 1)
-            (layers "F.Cu" "F.Mask" "F.Paste")
-            (net 9 "gnd")
-            (uuid "1ad59246-8234-44c6-a390-27fd18f476ed")
+        (fp_text user "%R"
+            (at 0 0 0)
+            (layer "F.Fab")
+            (uuid "d039ab6c-d1a1-498c-9657-c66e199ceb75")
+            (effects
+                (font
+                    (size 1 1)
+                    (thickness 0.15)
+                )
+            )
+            (unlocked no)
         )
-        (pad "3" smd rect
-            (at 0 2.3 180)
-            (size 0.3 1)
-            (layers "F.Cu" "F.Mask" "F.Paste")
-            (net 10 "hv")
-            (uuid "7fe797d8-b23b-4bb7-9eba-70f74399c2d3")
-        )
-        (pad "4" smd rect
-            (at 0.5 2.3 180)
-            (size 0.3 1)
-            (layers "F.Cu" "F.Mask" "F.Paste")
-            (net 7 "A1")
-            (uuid "632a7b0e-38aa-4310-8ef7-e25fa865f8ee")
-        )
-        (pad "5" smd rect
-            (at 1 2.3 180)
-            (size 0.3 1)
-            (layers "F.Cu" "F.Mask" "F.Paste")
-            (net 3 "A0")
-            (uuid "5fdf1d0b-07ef-45aa-a609-09e9c2d5e091")
-        )
-        (pad "6" smd rect
-            (at 1 -2.3 180)
-            (size 0.3 1)
-            (layers "F.Cu" "F.Mask" "F.Paste")
-            (net 1 "RH")
-            (uuid "a26eb265-235f-489c-9e2f-13fe2eb27b61")
-        )
-        (pad "7" smd rect
-            (at 0.5 -2.3 180)
-            (size 0.3 1)
-            (layers "F.Cu" "F.Mask" "F.Paste")
-            (net 5 "RW")
-            (uuid "827c00d4-57aa-4c23-b045-c81e28f0a374")
-        )
-        (pad "8" smd rect
-            (at 0 -2.3 180)
-            (size 0.3 1)
-            (layers "F.Cu" "F.Mask" "F.Paste")
-            (net 6 "RL")
-            (uuid "0599b212-bf59-4aef-9bf7-171aa0a0ce4e")
-        )
-        (pad "9" smd rect
-            (at -0.5 -2.3 180)
-            (size 0.3 1)
-            (layers "F.Cu" "F.Mask" "F.Paste")
-            (net 4 "Vpos")
-            (uuid "6ad4feca-ddd5-4065-8386-b3d505b9f13d")
+        (fp_text user "${REFERENCE}"
+            (at 0 -6.3 0)
+            (layer "F.SilkS")
+            (uuid "273d3afa-cadd-4833-8bfc-4861832b928e")
+            (effects
+                (font
+                    (size 1 1)
+                    (thickness 0.15)
+                )
+                (hide yes)
+            )
+            (unlocked no)
         )
         (pad "10" smd rect
             (at -1 -2.3 180)
             (size 0.3 1)
-            (layers "F.Cu" "F.Mask" "F.Paste")
+            (layers "F.Cu" "F.Paste" "F.Mask")
             (net 8 "SCL")
             (uuid "1e5a579e-e3fb-45c2-874a-68d7a3ab17bf")
         )
-        (embedded_fonts no)
+        (pad "9" smd rect
+            (at -0.5 -2.3 180)
+            (size 0.3 1)
+            (layers "F.Cu" "F.Paste" "F.Mask")
+            (net 4 "_wiper_bias-VCC")
+            (uuid "6ad4feca-ddd5-4065-8386-b3d505b9f13d")
+        )
+        (pad "8" smd rect
+            (at 0 -2.3 180)
+            (size 0.3 1)
+            (layers "F.Cu" "F.Paste" "F.Mask")
+            (net 6 "RL")
+            (uuid "0599b212-bf59-4aef-9bf7-171aa0a0ce4e")
+        )
+        (pad "7" smd rect
+            (at 0.5 -2.3 180)
+            (size 0.3 1)
+            (layers "F.Cu" "F.Paste" "F.Mask")
+            (net 5 "RW")
+            (uuid "827c00d4-57aa-4c23-b045-c81e28f0a374")
+        )
+        (pad "6" smd rect
+            (at 1 -2.3 180)
+            (size 0.3 1)
+            (layers "F.Cu" "F.Paste" "F.Mask")
+            (net 1 "RH")
+            (uuid "a26eb265-235f-489c-9e2f-13fe2eb27b61")
+        )
+        (pad "5" smd rect
+            (at 1 2.3 180)
+            (size 0.3 1)
+            (layers "F.Cu" "F.Paste" "F.Mask")
+            (net 3 "address_bit_0")
+            (uuid "5fdf1d0b-07ef-45aa-a609-09e9c2d5e091")
+        )
+        (pad "4" smd rect
+            (at 0.5 2.3 180)
+            (size 0.3 1)
+            (layers "F.Cu" "F.Paste" "F.Mask")
+            (net 7 "address_bit_1")
+            (uuid "632a7b0e-38aa-4310-8ef7-e25fa865f8ee")
+        )
+        (pad "3" smd rect
+            (at 0 2.3 180)
+            (size 0.3 1)
+            (layers "F.Cu" "F.Paste" "F.Mask")
+            (net 10 "power-VCC")
+            (uuid "7fe797d8-b23b-4bb7-9eba-70f74399c2d3")
+        )
+        (pad "2" smd rect
+            (at -0.5 2.3 180)
+            (size 0.3 1)
+            (layers "F.Cu" "F.Paste" "F.Mask")
+            (net 9 "GND")
+            (uuid "1ad59246-8234-44c6-a390-27fd18f476ed")
+        )
+        (pad "1" smd rect
+            (at -1 2.3 180)
+            (size 0.3 1)
+            (layers "F.Cu" "F.Paste" "F.Mask")
+            (net 2 "SDA")
+            (uuid "9f51ee0d-14b0-4bfa-af5f-b8259c072cf3")
+        )
         (model "${KIPRJMOD}/../../parts/Maxim_Integrated_DS3502U_T_R/UMAX-10_L3.0-W3.0-P0.50-LS4.9-BL.step"
             (offset
                 (xyz 0 0 0)

--- a/packages/maxim-ds3502/layouts/usage/usage.kicad_pcb
+++ b/packages/maxim-ds3502/layouts/usage/usage.kicad_pcb
@@ -88,12 +88,12 @@
     )
     (net 0 "")
     (net 1 "SDA")
-    (net 2 "pot-hv")
-    (net 3 "gnd")
-    (net 4 "A0")
-    (net 5 "A1")
+    (net 2 "_wiper_bias-VCC")
+    (net 3 "GND")
+    (net 4 "address_bit_0")
+    (net 5 "address_bit_1")
     (net 6 "RW")
-    (net 7 "-hv")
+    (net 7 "power-VCC")
     (net 8 "SCL")
     (net 9 "RL")
     (net 10 "RH")
@@ -105,7 +105,7 @@
             (at 0 -4 0)
             (layer "F.SilkS")
             (hide yes)
-            (uuid "ad284745-9833-42b3-8cc0-c68af5d9bcdf")
+            (uuid "c93e4c64-f84f-4e03-9a45-25a8f9965aa5")
             (effects
                 (font
                     (size 1 1)
@@ -117,7 +117,7 @@
             (at 0 4 0)
             (layer "F.Fab")
             (hide no)
-            (uuid "d974e539-e7dd-4765-a570-7bbdb0e66bb5")
+            (uuid "5c6dc7bf-ced8-4d2e-8d14-1e3dde8315fa")
             (effects
                 (font
                     (size 1 1)
@@ -153,7 +153,7 @@
             (at 0 0 0)
             (layer "User.9")
             (hide no)
-            (uuid "a2376b8b-547e-48b3-a361-a2658db62fdf")
+            (uuid "f06d41c2-23e8-498c-bf32-1101afc66fc9")
             (effects
                 (font
                     (size 0.125 0.125)
@@ -162,11 +162,11 @@
                 (hide yes)
             )
         )
-        (property "__atopile_lib_fp_hash__" "f92c29e2-6901-2273-8c64-0d6fc82f7c3a"
+        (property "__atopile_lib_fp_hash__" "66a6df7a-35db-d48c-1b44-17c6253711c4"
             (at 0 0 0)
             (layer "User.9")
             (hide yes)
-            (uuid "df8702f8-eca2-4889-9dcd-8f684642524b")
+            (uuid "a9be7bd5-7a26-4f03-8513-29c94642524b")
             (effects
                 (font
                     (size 0.125 0.125)
@@ -258,6 +258,18 @@
                 )
             )
         )
+        (property "atopile_subaddresses" "[layouts/default/default.kicad_pcb:i2c_pullups[1]]"
+            (at 0 0 0)
+            (layer "User.9")
+            (hide yes)
+            (uuid "4a74fbe5-1dbe-4c30-b372-51a24642524b")
+            (effects
+                (font
+                    (size 0.125 0.125)
+                    (thickness 0.01875)
+                )
+            )
+        )
         (attr smd)
         (fp_line
             (start -0.23 0.5)
@@ -267,7 +279,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "5befe651-52a8-4c8b-9bfc-b0ab1edff76a")
+            (uuid "be005586-56f1-4209-92be-84195bf4394f")
         )
         (fp_line
             (start -0.94 0.5)
@@ -277,7 +289,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "7abb75bd-2be3-437d-b292-38d11cb8398b")
+            (uuid "82f9b388-d606-4124-a8d4-5603c7c3f6c7")
         )
         (fp_line
             (start -0.94 -0.5)
@@ -287,7 +299,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "1b9d747c-9c47-492f-a404-8a52f180379d")
+            (uuid "3575d6e5-ed5a-43a9-9bc6-9385da1e64f5")
         )
         (fp_line
             (start 0.23 0.5)
@@ -297,7 +309,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "d825b4d7-de00-4ecf-9ff9-751b9aaa6aa9")
+            (uuid "c87d7556-597e-4f5e-964a-24d1efa25d69")
         )
         (fp_line
             (start 0.94 0.5)
@@ -307,7 +319,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "c4ebbb1f-1a69-48ac-a86c-44d30310c8a7")
+            (uuid "345b711c-48b6-4f80-8822-8cfbd1c77b61")
         )
         (fp_line
             (start 0.94 -0.5)
@@ -317,7 +329,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "d4cc2a9a-d2f6-4017-ac78-efaee4f9be54")
+            (uuid "50be0952-01be-44af-80f1-d4bbbf52dd80")
         )
         (fp_circle
             (center -0.5 0.25)
@@ -328,12 +340,12 @@
             )
             (fill no)
             (layer "F.Fab")
-            (uuid "3515a81f-9a9e-4b67-b6c4-0b80b0565bfb")
+            (uuid "9bdc7b50-73ab-44fb-9cee-547ffd8f532c")
         )
         (fp_text user "%R"
             (at 0 0 0)
             (layer "F.Fab")
-            (uuid "76f67181-80f0-466f-aa38-806898fc7679")
+            (uuid "0cdd0574-28dd-44fb-bc4e-b660e9e44d74")
             (effects
                 (font
                     (size 1 1)
@@ -345,7 +357,7 @@
         (fp_text user "${REFERENCE}"
             (at 0 -4 0)
             (layer "F.SilkS")
-            (uuid "ad284745-9833-42b3-8cc0-c68af5d9bcdf")
+            (uuid "c93e4c64-f84f-4e03-9a45-25a8f9965aa5")
             (effects
                 (font
                     (size 1 1)
@@ -359,15 +371,15 @@
             (at 0.43 0 -90)
             (size 0.57 0.54)
             (layers "F.Cu" "F.Paste" "F.Mask")
-            (net 7 "-hv")
-            (uuid "199e29a8-7c4b-47c7-8168-5f4cd81c33a8")
+            (net 7 "power-VCC")
+            (uuid "fdf46de2-1ee2-4a0a-be6b-919a81618593")
         )
         (pad "1" smd rect
             (at -0.43 0 -90)
             (size 0.57 0.54)
             (layers "F.Cu" "F.Paste" "F.Mask")
             (net 1 "SDA")
-            (uuid "9100c6c8-154a-4949-9b6a-230cdc0a9d8d")
+            (uuid "b5674ebe-8491-4a36-b544-83fba3091727")
         )
         (model "${KIPRJMOD}/../../parts/UNI_ROYAL_0402WGF4701TCE/R0402_L1.0-W0.5-H0.4.step"
             (offset
@@ -389,7 +401,7 @@
             (at 0 -4 0)
             (layer "F.SilkS")
             (hide yes)
-            (uuid "ad284745-9833-42b3-8cc0-c68af5d9bcdf")
+            (uuid "c93e4c64-f84f-4e03-9a45-25a8f9965aa5")
             (effects
                 (font
                     (size 1 1)
@@ -401,7 +413,7 @@
             (at 0 4 0)
             (layer "F.Fab")
             (hide no)
-            (uuid "d974e539-e7dd-4765-a570-7bbdb0e66bb5")
+            (uuid "5c6dc7bf-ced8-4d2e-8d14-1e3dde8315fa")
             (effects
                 (font
                     (size 1 1)
@@ -437,7 +449,7 @@
             (at 0 0 0)
             (layer "User.9")
             (hide no)
-            (uuid "a2376b8b-547e-48b3-a361-a2658db62fdf")
+            (uuid "f06d41c2-23e8-498c-bf32-1101afc66fc9")
             (effects
                 (font
                     (size 0.125 0.125)
@@ -446,11 +458,11 @@
                 (hide yes)
             )
         )
-        (property "__atopile_lib_fp_hash__" "f92c29e2-6901-2273-8c64-0d6fc82f7c3a"
+        (property "__atopile_lib_fp_hash__" "66a6df7a-35db-d48c-1b44-17c6253711c4"
             (at 0 0 0)
             (layer "User.9")
             (hide yes)
-            (uuid "05752871-200b-486e-aab2-13374642524b")
+            (uuid "f827dcee-aee0-4cc9-b210-3e944642524b")
             (effects
                 (font
                     (size 0.125 0.125)
@@ -542,6 +554,18 @@
                 )
             )
         )
+        (property "atopile_subaddresses" "[layouts/default/default.kicad_pcb:i2c_pullups[0]]"
+            (at 0 0 0)
+            (layer "User.9")
+            (hide yes)
+            (uuid "310f2c15-ee54-40e5-b2ba-05cf4642524b")
+            (effects
+                (font
+                    (size 0.125 0.125)
+                    (thickness 0.01875)
+                )
+            )
+        )
         (attr smd)
         (fp_line
             (start -0.23 0.5)
@@ -551,7 +575,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "5befe651-52a8-4c8b-9bfc-b0ab1edff76a")
+            (uuid "be005586-56f1-4209-92be-84195bf4394f")
         )
         (fp_line
             (start -0.94 0.5)
@@ -561,7 +585,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "7abb75bd-2be3-437d-b292-38d11cb8398b")
+            (uuid "82f9b388-d606-4124-a8d4-5603c7c3f6c7")
         )
         (fp_line
             (start -0.94 -0.5)
@@ -571,7 +595,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "1b9d747c-9c47-492f-a404-8a52f180379d")
+            (uuid "3575d6e5-ed5a-43a9-9bc6-9385da1e64f5")
         )
         (fp_line
             (start 0.23 0.5)
@@ -581,7 +605,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "d825b4d7-de00-4ecf-9ff9-751b9aaa6aa9")
+            (uuid "c87d7556-597e-4f5e-964a-24d1efa25d69")
         )
         (fp_line
             (start 0.94 0.5)
@@ -591,7 +615,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "c4ebbb1f-1a69-48ac-a86c-44d30310c8a7")
+            (uuid "345b711c-48b6-4f80-8822-8cfbd1c77b61")
         )
         (fp_line
             (start 0.94 -0.5)
@@ -601,7 +625,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "d4cc2a9a-d2f6-4017-ac78-efaee4f9be54")
+            (uuid "50be0952-01be-44af-80f1-d4bbbf52dd80")
         )
         (fp_circle
             (center -0.5 0.25)
@@ -612,12 +636,12 @@
             )
             (fill no)
             (layer "F.Fab")
-            (uuid "3515a81f-9a9e-4b67-b6c4-0b80b0565bfb")
+            (uuid "9bdc7b50-73ab-44fb-9cee-547ffd8f532c")
         )
         (fp_text user "%R"
             (at 0 0 0)
             (layer "F.Fab")
-            (uuid "76f67181-80f0-466f-aa38-806898fc7679")
+            (uuid "0cdd0574-28dd-44fb-bc4e-b660e9e44d74")
             (effects
                 (font
                     (size 1 1)
@@ -629,7 +653,7 @@
         (fp_text user "${REFERENCE}"
             (at 0 -4 0)
             (layer "F.SilkS")
-            (uuid "ad284745-9833-42b3-8cc0-c68af5d9bcdf")
+            (uuid "c93e4c64-f84f-4e03-9a45-25a8f9965aa5")
             (effects
                 (font
                     (size 1 1)
@@ -643,15 +667,15 @@
             (at 0.43 0 -90)
             (size 0.57 0.54)
             (layers "F.Cu" "F.Paste" "F.Mask")
-            (net 7 "-hv")
-            (uuid "199e29a8-7c4b-47c7-8168-5f4cd81c33a8")
+            (net 7 "power-VCC")
+            (uuid "fdf46de2-1ee2-4a0a-be6b-919a81618593")
         )
         (pad "1" smd rect
             (at -0.43 0 -90)
             (size 0.57 0.54)
             (layers "F.Cu" "F.Paste" "F.Mask")
             (net 8 "SCL")
-            (uuid "9100c6c8-154a-4949-9b6a-230cdc0a9d8d")
+            (uuid "b5674ebe-8491-4a36-b544-83fba3091727")
         )
         (model "${KIPRJMOD}/../../parts/UNI_ROYAL_0402WGF4701TCE/R0402_L1.0-W0.5-H0.4.step"
             (offset
@@ -720,20 +744,21 @@
         (property "checksum" "4c74edf4b82d05aba1ec889a3eda19af01524de14752a39757003aefc72fb346"
             (at 0 0 0)
             (layer "User.9")
-            (hide yes)
+            (hide no)
             (uuid "0de809c2-4b49-4ba3-aa01-35d4d0352b67")
             (effects
                 (font
                     (size 0.125 0.125)
                     (thickness 0.01875)
                 )
+                (hide yes)
             )
         )
-        (property "__atopile_lib_fp_hash__" "5a65c929-18de-debf-e420-aa36680425bf"
+        (property "__atopile_lib_fp_hash__" "76953ce2-ce42-346e-26a4-3cca14fbd08e"
             (at 0 0 0)
             (layer "User.9")
             (hide yes)
-            (uuid "508944b5-1f00-4c8e-924d-ef404642524b")
+            (uuid "f0332584-274d-4ce2-a1f4-9c3f4642524b")
             (effects
                 (font
                     (size 0.125 0.125)
@@ -789,17 +814,19 @@
                 )
             )
         )
-        (attr smd)
-        (fp_line
-            (start -1.5 -1.5)
-            (end -1.5 -0.5)
-            (stroke
-                (width 0.25)
-                (type solid)
+        (property "atopile_subaddresses" "[layouts/default/default.kicad_pcb:package]"
+            (at 0 0 0)
+            (layer "User.9")
+            (hide yes)
+            (uuid "13124ac1-4fc1-40c0-8e4b-423a4642524b")
+            (effects
+                (font
+                    (size 0.125 0.125)
+                    (thickness 0.01875)
+                )
             )
-            (layer "F.SilkS")
-            (uuid "6c8e7395-3461-4b72-82f0-4019667c8c83")
         )
+        (attr smd)
         (fp_line
             (start -1.5 1.5)
             (end -1.5 0.5)
@@ -809,16 +836,6 @@
             )
             (layer "F.SilkS")
             (uuid "6cb8d312-1812-4dce-9973-5498dc6e1bd6")
-        )
-        (fp_line
-            (start -1.5 1.5)
-            (end 1.5 1.5)
-            (stroke
-                (width 0.25)
-                (type solid)
-            )
-            (layer "F.SilkS")
-            (uuid "dea3b296-0325-489f-a054-d8e543ede702")
         )
         (fp_line
             (start 1.5 -1.5)
@@ -840,27 +857,36 @@
             (layer "F.SilkS")
             (uuid "e770ddfd-4549-4c7b-9d12-809769d4cc32")
         )
+        (fp_line
+            (start -1.5 1.5)
+            (end 1.5 1.5)
+            (stroke
+                (width 0.25)
+                (type solid)
+            )
+            (layer "F.SilkS")
+            (uuid "dea3b296-0325-489f-a054-d8e543ede702")
+        )
+        (fp_line
+            (start -1.5 -1.5)
+            (end -1.5 -0.5)
+            (stroke
+                (width 0.25)
+                (type solid)
+            )
+            (layer "F.SilkS")
+            (uuid "6c8e7395-3461-4b72-82f0-4019667c8c83")
+        )
         (fp_arc
-            (start -1.508726 0.499924)
-            (mid -1.495655 -0.499981)
-            (end -1.5 0.5)
+            (start -1.5 0.5)
+            (mid -1.495636732250813 -0.49998096153208565)
+            (end -1.5087262032186417 0.49992384757819563)
             (stroke
                 (width 0.25)
                 (type solid)
             )
             (layer "F.SilkS")
             (uuid "aed70457-ecd6-409c-affb-007db905b95d")
-        )
-        (fp_circle
-            (center -1.1 2.3)
-            (end -0.98 2.3)
-            (stroke
-                (width 0.25)
-                (type solid)
-            )
-            (fill no)
-            (layer "Cmts.User")
-            (uuid "55485294-0965-419a-8ec1-2b9460cfc60c")
         )
         (fp_circle
             (center -1.5 2.45)
@@ -873,10 +899,33 @@
             (layer "F.Fab")
             (uuid "b8e020b0-f789-426c-a72c-ae3533a8bead")
         )
-        (fp_text user "${REFERENCE}"
+        (fp_circle
+            (center -1.1 2.3)
+            (end -0.98 2.3)
+            (stroke
+                (width 0.25)
+                (type solid)
+            )
+            (fill no)
+            (layer "Cmts.User")
+            (uuid "55485294-0965-419a-8ec1-2b9460cfc60c")
+        )
+        (fp_text user "%R"
             (at 0 0 0)
             (layer "F.Fab")
             (uuid "d039ab6c-d1a1-498c-9657-c66e199ceb75")
+            (effects
+                (font
+                    (size 1 1)
+                    (thickness 0.15)
+                )
+            )
+            (unlocked no)
+        )
+        (fp_text user "${REFERENCE}"
+            (at 0 -6.3 0)
+            (layer "F.SilkS")
+            (uuid "273d3afa-cadd-4833-8bfc-4861832b928e")
             (effects
                 (font
                     (size 1 1)
@@ -886,77 +935,76 @@
             )
             (unlocked no)
         )
-        (pad "1" smd rect
-            (at -1 2.3 180)
+        (pad "10" smd rect
+            (at -1 -2.3 180)
             (size 0.3 1)
-            (layers "F.Cu" "F.Mask" "F.Paste")
-            (net 1 "SDA")
-            (uuid "9f51ee0d-14b0-4bfa-af5f-b8259c072cf3")
-        )
-        (pad "2" smd rect
-            (at -0.5 2.3 180)
-            (size 0.3 1)
-            (layers "F.Cu" "F.Mask" "F.Paste")
-            (net 3 "gnd")
-            (uuid "1ad59246-8234-44c6-a390-27fd18f476ed")
-        )
-        (pad "3" smd rect
-            (at 0 2.3 180)
-            (size 0.3 1)
-            (layers "F.Cu" "F.Mask" "F.Paste")
-            (net 7 "-hv")
-            (uuid "7fe797d8-b23b-4bb7-9eba-70f74399c2d3")
-        )
-        (pad "4" smd rect
-            (at 0.5 2.3 180)
-            (size 0.3 1)
-            (layers "F.Cu" "F.Mask" "F.Paste")
-            (net 5 "A1")
-            (uuid "632a7b0e-38aa-4310-8ef7-e25fa865f8ee")
-        )
-        (pad "5" smd rect
-            (at 1 2.3 180)
-            (size 0.3 1)
-            (layers "F.Cu" "F.Mask" "F.Paste")
-            (net 4 "A0")
-            (uuid "5fdf1d0b-07ef-45aa-a609-09e9c2d5e091")
-        )
-        (pad "6" smd rect
-            (at 1 -2.3 180)
-            (size 0.3 1)
-            (layers "F.Cu" "F.Mask" "F.Paste")
-            (net 10 "RH")
-            (uuid "a26eb265-235f-489c-9e2f-13fe2eb27b61")
-        )
-        (pad "7" smd rect
-            (at 0.5 -2.3 180)
-            (size 0.3 1)
-            (layers "F.Cu" "F.Mask" "F.Paste")
-            (net 6 "RW")
-            (uuid "827c00d4-57aa-4c23-b045-c81e28f0a374")
-        )
-        (pad "8" smd rect
-            (at 0 -2.3 180)
-            (size 0.3 1)
-            (layers "F.Cu" "F.Mask" "F.Paste")
-            (net 9 "RL")
-            (uuid "0599b212-bf59-4aef-9bf7-171aa0a0ce4e")
+            (layers "F.Cu" "F.Paste" "F.Mask")
+            (net 8 "SCL")
+            (uuid "1e5a579e-e3fb-45c2-874a-68d7a3ab17bf")
         )
         (pad "9" smd rect
             (at -0.5 -2.3 180)
             (size 0.3 1)
-            (layers "F.Cu" "F.Mask" "F.Paste")
-            (net 2 "pot-hv")
+            (layers "F.Cu" "F.Paste" "F.Mask")
+            (net 2 "_wiper_bias-VCC")
             (uuid "6ad4feca-ddd5-4065-8386-b3d505b9f13d")
         )
-        (pad "10" smd rect
-            (at -1 -2.3 180)
+        (pad "8" smd rect
+            (at 0 -2.3 180)
             (size 0.3 1)
-            (layers "F.Cu" "F.Mask" "F.Paste")
-            (net 8 "SCL")
-            (uuid "1e5a579e-e3fb-45c2-874a-68d7a3ab17bf")
+            (layers "F.Cu" "F.Paste" "F.Mask")
+            (net 9 "RL")
+            (uuid "0599b212-bf59-4aef-9bf7-171aa0a0ce4e")
         )
-        (embedded_fonts no)
+        (pad "7" smd rect
+            (at 0.5 -2.3 180)
+            (size 0.3 1)
+            (layers "F.Cu" "F.Paste" "F.Mask")
+            (net 6 "RW")
+            (uuid "827c00d4-57aa-4c23-b045-c81e28f0a374")
+        )
+        (pad "6" smd rect
+            (at 1 -2.3 180)
+            (size 0.3 1)
+            (layers "F.Cu" "F.Paste" "F.Mask")
+            (net 10 "RH")
+            (uuid "a26eb265-235f-489c-9e2f-13fe2eb27b61")
+        )
+        (pad "5" smd rect
+            (at 1 2.3 180)
+            (size 0.3 1)
+            (layers "F.Cu" "F.Paste" "F.Mask")
+            (net 4 "address_bit_0")
+            (uuid "5fdf1d0b-07ef-45aa-a609-09e9c2d5e091")
+        )
+        (pad "4" smd rect
+            (at 0.5 2.3 180)
+            (size 0.3 1)
+            (layers "F.Cu" "F.Paste" "F.Mask")
+            (net 5 "address_bit_1")
+            (uuid "632a7b0e-38aa-4310-8ef7-e25fa865f8ee")
+        )
+        (pad "3" smd rect
+            (at 0 2.3 180)
+            (size 0.3 1)
+            (layers "F.Cu" "F.Paste" "F.Mask")
+            (net 7 "power-VCC")
+            (uuid "7fe797d8-b23b-4bb7-9eba-70f74399c2d3")
+        )
+        (pad "2" smd rect
+            (at -0.5 2.3 180)
+            (size 0.3 1)
+            (layers "F.Cu" "F.Paste" "F.Mask")
+            (net 3 "GND")
+            (uuid "1ad59246-8234-44c6-a390-27fd18f476ed")
+        )
+        (pad "1" smd rect
+            (at -1 2.3 180)
+            (size 0.3 1)
+            (layers "F.Cu" "F.Paste" "F.Mask")
+            (net 1 "SDA")
+            (uuid "9f51ee0d-14b0-4bfa-af5f-b8259c072cf3")
+        )
         (model "${KIPRJMOD}/../../parts/Maxim_Integrated_DS3502U_T_R/UMAX-10_L3.0-W3.0-P0.50-LS4.9-BL.step"
             (offset
                 (xyz 0 0 0)
@@ -977,7 +1025,7 @@
             (at 0 -4 0)
             (layer "F.SilkS")
             (hide yes)
-            (uuid "5e177789-2837-437e-8257-1916b8e6c0dc")
+            (uuid "cb4fbbfd-b4ec-44f5-8611-fe7814d3e386")
             (effects
                 (font
                     (size 1 1)
@@ -989,7 +1037,7 @@
             (at 0 4 0)
             (layer "F.Fab")
             (hide no)
-            (uuid "1975453c-41cd-43e4-b285-9bd82ed47cf3")
+            (uuid "0f7b39bd-edda-4a60-8aa3-1a828bc8aebe")
             (effects
                 (font
                     (size 1 1)
@@ -1025,7 +1073,7 @@
             (at 0 0 0)
             (layer "User.9")
             (hide no)
-            (uuid "5a5cc632-4266-4ab7-acb3-aa0b5ced6429")
+            (uuid "179c408f-6235-486d-a1b3-8725ede7f89a")
             (effects
                 (font
                     (size 0.125 0.125)
@@ -1034,11 +1082,11 @@
                 (hide yes)
             )
         )
-        (property "__atopile_lib_fp_hash__" "f8cfc16c-2d15-25d8-bcf0-af889ed0beb7"
+        (property "__atopile_lib_fp_hash__" "abd85f6b-95fa-ed5a-88fe-be39d3a76574"
             (at 0 0 0)
             (layer "User.9")
             (hide yes)
-            (uuid "a1a446e7-1662-4280-b9f4-a15c4642524b")
+            (uuid "69f51e2a-88d9-4d84-8965-c9484642524b")
             (effects
                 (font
                     (size 0.125 0.125)
@@ -1130,6 +1178,18 @@
                 )
             )
         )
+        (property "atopile_subaddresses" "[layouts/default/default.kicad_pcb:decoupling_capacitor]"
+            (at 0 0 0)
+            (layer "User.9")
+            (hide yes)
+            (uuid "caec3e02-9a83-487c-b721-27e84642524b")
+            (effects
+                (font
+                    (size 0.125 0.125)
+                    (thickness 0.01875)
+                )
+            )
+        )
         (attr smd)
         (fp_line
             (start 1.02 -0.5)
@@ -1139,7 +1199,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "6df3d865-6925-4a87-91e0-e2fa9d86d1e9")
+            (uuid "623226e1-f11e-4267-bfac-71c433a52cc8")
         )
         (fp_line
             (start 0.23 0.5)
@@ -1149,7 +1209,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "1f764452-8f3e-4a06-8bf3-231cde5820a9")
+            (uuid "8cf5ccaf-11ed-4407-a114-a53eca8621f3")
         )
         (fp_line
             (start 1.17 0.35)
@@ -1159,7 +1219,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "675a029f-688e-4551-9ac6-b20831028752")
+            (uuid "0cd6722a-2e99-445a-96aa-c3aeb88d2622")
         )
         (fp_line
             (start -1.02 -0.5)
@@ -1169,7 +1229,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "1c1fe559-c8a2-4fca-9702-5261c0857ddc")
+            (uuid "4ca2b9ee-3fab-4d8b-8519-5d00b34e35bf")
         )
         (fp_line
             (start -0.23 0.5)
@@ -1179,7 +1239,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "45a754a9-ab3a-474c-8458-5682120ca908")
+            (uuid "683133b9-0809-45eb-9a6f-8d8ca75d12d7")
         )
         (fp_line
             (start -1.17 0.35)
@@ -1189,7 +1249,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "35ef18a2-a449-4935-a6c0-02607ab431e9")
+            (uuid "0d8bfb30-430e-49f5-b63c-26e9cd5f317c")
         )
         (fp_arc
             (start 1.17 0.35)
@@ -1200,7 +1260,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "bf9b4495-0b7d-48bf-96a5-42ab918b1702")
+            (uuid "75f68864-4668-4460-89b2-237577480af1")
         )
         (fp_arc
             (start 1.02 -0.5)
@@ -1211,7 +1271,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "4413cb63-cd6c-4e58-91dc-0c4bb5e481f2")
+            (uuid "fdd6bfb0-c576-4f83-9779-0b9065a71285")
         )
         (fp_arc
             (start -1.17 0.35)
@@ -1222,7 +1282,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "68322da5-760e-477b-9e32-04b7189198c6")
+            (uuid "5b021e40-c54f-41d9-b4d5-16d2e0b32419")
         )
         (fp_arc
             (start -1.02 -0.5)
@@ -1233,7 +1293,7 @@
                 (type solid)
             )
             (layer "F.SilkS")
-            (uuid "be848dc7-9690-4aaa-b89b-97688c338439")
+            (uuid "680a4095-09ec-4aaf-aa4b-a3a3c3fd1941")
         )
         (fp_circle
             (center -0.5 0.25)
@@ -1244,12 +1304,12 @@
             )
             (fill no)
             (layer "F.Fab")
-            (uuid "0f4dba9d-e19b-4e04-9043-031ca93a8c07")
+            (uuid "30315650-4766-480e-b600-111bad2e2cb1")
         )
         (fp_text user "%R"
             (at 0 0 0)
             (layer "F.Fab")
-            (uuid "4c2d32f2-e3af-46e4-bcae-68cb9044daed")
+            (uuid "d1f18b3c-2dc6-4029-b037-7fbbab090a99")
             (effects
                 (font
                     (size 1 1)
@@ -1261,7 +1321,7 @@
         (fp_text user "${REFERENCE}"
             (at 0 -4 0)
             (layer "F.SilkS")
-            (uuid "5e177789-2837-437e-8257-1916b8e6c0dc")
+            (uuid "cb4fbbfd-b4ec-44f5-8611-fe7814d3e386")
             (effects
                 (font
                     (size 1 1)
@@ -1275,15 +1335,15 @@
             (at 0.55 0 -90)
             (size 0.79 0.54)
             (layers "F.Cu" "F.Paste" "F.Mask")
-            (net 3 "gnd")
-            (uuid "c96cc429-398b-4b3d-8a36-e1656f3d1c29")
+            (net 3 "GND")
+            (uuid "f443ec50-760f-410d-80c7-c0631c312cf2")
         )
         (pad "1" smd rect
             (at -0.55 0 -90)
             (size 0.79 0.54)
             (layers "F.Cu" "F.Paste" "F.Mask")
-            (net 7 "-hv")
-            (uuid "141ecb78-15fc-43f7-83a0-032c852990f8")
+            (net 7 "power-VCC")
+            (uuid "a25d49bc-c3c4-408f-9aa0-d394ef8121a3")
         )
         (model "${KIPRJMOD}/../../parts/Samsung_Electro_Mechanics_CL05B104KO5NNNC/C0402_L1.0-W0.5-H0.5.step"
             (offset
@@ -1404,6 +1464,6 @@
     )
     (group "pot"
         (uuid "7e3b64d7-297a-48e0-a0e9-35ef59cc4622")
-        (members "093b3bca-bd19-4476-8746-e909cadea69d" "0bb689db-203c-458a-abf4-d72b15690ec9" "1b8da374-590d-4428-b09a-71e9626a9e70" "3be0e283-c12b-4677-b052-f977539854f8" "3c14247b-a42c-4c44-aa18-34ce4642524b" "3e556860-1e86-47a1-a5c0-bcf0aee650f8" "4a11890f-4243-4ddb-816f-05cd2cedbea8" "52342552-6a12-4864-b510-7726d444789a" "76e73315-5267-43ee-9dc4-2808f3b9f43b" "83f446d5-8948-4f7a-bd8a-50fba8e1fdec" "85c2b478-ec74-4a4a-a73f-5cfc4642524b" "8c9da72e-6a81-49a1-9f18-fc9f00cf091a" "8e10a5c0-faab-4a63-b201-75144642524b" "97c0c9fa-8054-47c2-bcd9-c4e94642524b" "c5a33847-319b-46a1-863d-b459a577ca91" "cddc6360-80d0-42e6-9647-6f9371e28368" "d93bf379-3ca6-40c8-83b0-40fead433795")
+        (members "8c9da72e-6a81-49a1-9f18-fc9f00cf091a" "d93bf379-3ca6-40c8-83b0-40fead433795" "3be0e283-c12b-4677-b052-f977539854f8" "76e73315-5267-43ee-9dc4-2808f3b9f43b" "85c2b478-ec74-4a4a-a73f-5cfc4642524b" "3c14247b-a42c-4c44-aa18-34ce4642524b" "4a11890f-4243-4ddb-816f-05cd2cedbea8" "83f446d5-8948-4f7a-bd8a-50fba8e1fdec" "c5a33847-319b-46a1-863d-b459a577ca91" "cddc6360-80d0-42e6-9647-6f9371e28368" "8e10a5c0-faab-4a63-b201-75144642524b" "1b8da374-590d-4428-b09a-71e9626a9e70" "97c0c9fa-8054-47c2-bcd9-c4e94642524b" "3e556860-1e86-47a1-a5c0-bcf0aee650f8" "093b3bca-bd19-4476-8746-e909cadea69d" "0bb689db-203c-458a-abf4-d72b15690ec9" "52342552-6a12-4864-b510-7726d444789a")
     )
 )

--- a/packages/maxim-ds3502/parts/Samsung_Electro_Mechanics_CL05B104KO5NNNC/C0402.kicad_mod
+++ b/packages/maxim-ds3502/parts/Samsung_Electro_Mechanics_CL05B104KO5NNNC/C0402.kicad_mod
@@ -9,7 +9,7 @@
         (at 0 -4 0)
         (layer "F.SilkS")
         (hide no)
-        (uuid "5e177789-2837-437e-8257-1916b8e6c0dc")
+        (uuid "cb4fbbfd-b4ec-44f5-8611-fe7814d3e386")
         (effects
             (font
                 (size 1 1)
@@ -21,7 +21,7 @@
         (at 0 4 0)
         (layer "F.Fab")
         (hide no)
-        (uuid "1975453c-41cd-43e4-b285-9bd82ed47cf3")
+        (uuid "0f7b39bd-edda-4a60-8aa3-1a828bc8aebe")
         (effects
             (font
                 (size 1 1)
@@ -33,7 +33,7 @@
         (at 0 0 0)
         (layer "User.9")
         (hide no)
-        (uuid "5a5cc632-4266-4ab7-acb3-aa0b5ced6429")
+        (uuid "179c408f-6235-486d-a1b3-8725ede7f89a")
         (effects
             (font
                 (size 0.125 0.125)
@@ -51,7 +51,7 @@
             (type solid)
         )
         (layer "F.SilkS")
-        (uuid "6df3d865-6925-4a87-91e0-e2fa9d86d1e9")
+        (uuid "623226e1-f11e-4267-bfac-71c433a52cc8")
     )
     (fp_line
         (start 0.23 0.5)
@@ -61,7 +61,7 @@
             (type solid)
         )
         (layer "F.SilkS")
-        (uuid "1f764452-8f3e-4a06-8bf3-231cde5820a9")
+        (uuid "8cf5ccaf-11ed-4407-a114-a53eca8621f3")
     )
     (fp_line
         (start 1.17 0.35)
@@ -71,7 +71,7 @@
             (type solid)
         )
         (layer "F.SilkS")
-        (uuid "675a029f-688e-4551-9ac6-b20831028752")
+        (uuid "0cd6722a-2e99-445a-96aa-c3aeb88d2622")
     )
     (fp_line
         (start -1.02 -0.5)
@@ -81,7 +81,7 @@
             (type solid)
         )
         (layer "F.SilkS")
-        (uuid "1c1fe559-c8a2-4fca-9702-5261c0857ddc")
+        (uuid "4ca2b9ee-3fab-4d8b-8519-5d00b34e35bf")
     )
     (fp_line
         (start -0.23 0.5)
@@ -91,7 +91,7 @@
             (type solid)
         )
         (layer "F.SilkS")
-        (uuid "45a754a9-ab3a-474c-8458-5682120ca908")
+        (uuid "683133b9-0809-45eb-9a6f-8d8ca75d12d7")
     )
     (fp_line
         (start -1.17 0.35)
@@ -101,7 +101,7 @@
             (type solid)
         )
         (layer "F.SilkS")
-        (uuid "35ef18a2-a449-4935-a6c0-02607ab431e9")
+        (uuid "0d8bfb30-430e-49f5-b63c-26e9cd5f317c")
     )
     (fp_arc
         (start 1.17 0.35)
@@ -112,7 +112,7 @@
             (type solid)
         )
         (layer "F.SilkS")
-        (uuid "bf9b4495-0b7d-48bf-96a5-42ab918b1702")
+        (uuid "75f68864-4668-4460-89b2-237577480af1")
     )
     (fp_arc
         (start 1.02 -0.5)
@@ -123,7 +123,7 @@
             (type solid)
         )
         (layer "F.SilkS")
-        (uuid "4413cb63-cd6c-4e58-91dc-0c4bb5e481f2")
+        (uuid "fdd6bfb0-c576-4f83-9779-0b9065a71285")
     )
     (fp_arc
         (start -1.17 0.35)
@@ -134,7 +134,7 @@
             (type solid)
         )
         (layer "F.SilkS")
-        (uuid "68322da5-760e-477b-9e32-04b7189198c6")
+        (uuid "5b021e40-c54f-41d9-b4d5-16d2e0b32419")
     )
     (fp_arc
         (start -1.02 -0.5)
@@ -145,7 +145,7 @@
             (type solid)
         )
         (layer "F.SilkS")
-        (uuid "be848dc7-9690-4aaa-b89b-97688c338439")
+        (uuid "680a4095-09ec-4aaf-aa4b-a3a3c3fd1941")
     )
     (fp_circle
         (center -0.5 0.25)
@@ -156,12 +156,12 @@
         )
         (fill no)
         (layer "F.Fab")
-        (uuid "0f4dba9d-e19b-4e04-9043-031ca93a8c07")
+        (uuid "30315650-4766-480e-b600-111bad2e2cb1")
     )
     (fp_text user "%R"
         (at 0 0 0)
         (layer "F.Fab")
-        (uuid "4c2d32f2-e3af-46e4-bcae-68cb9044daed")
+        (uuid "d1f18b3c-2dc6-4029-b037-7fbbab090a99")
         (effects
             (font
                 (size 1 1)
@@ -173,7 +173,7 @@
     (fp_text user "${REFERENCE}"
         (at 0 -4 0)
         (layer "F.SilkS")
-        (uuid "5e177789-2837-437e-8257-1916b8e6c0dc")
+        (uuid "cb4fbbfd-b4ec-44f5-8611-fe7814d3e386")
         (effects
             (font
                 (size 1 1)
@@ -186,13 +186,13 @@
         (at 0.55 0 0)
         (size 0.79 0.54)
         (layers "F.Cu" "F.Paste" "F.Mask")
-        (uuid "c96cc429-398b-4b3d-8a36-e1656f3d1c29")
+        (uuid "f443ec50-760f-410d-80c7-c0631c312cf2")
     )
     (pad "1" smd rect
         (at -0.55 0 0)
         (size 0.79 0.54)
         (layers "F.Cu" "F.Paste" "F.Mask")
-        (uuid "141ecb78-15fc-43f7-83a0-032c852990f8")
+        (uuid "a25d49bc-c3c4-408f-9aa0-d394ef8121a3")
     )
     (model "${KIPRJMOD}/../../parts/Samsung_Electro_Mechanics_CL05B104KO5NNNC/C0402_L1.0-W0.5-H0.5.step"
         (offset

--- a/packages/maxim-ds3502/parts/Samsung_Electro_Mechanics_CL05B104KO5NNNC/Samsung_Electro_Mechanics_CL05B104KO5NNNC.ato
+++ b/packages/maxim-ds3502/parts/Samsung_Electro_Mechanics_CL05B104KO5NNNC/Samsung_Electro_Mechanics_CL05B104KO5NNNC.ato
@@ -1,5 +1,4 @@
 #pragma experiment("TRAITS")
-import has_datasheet_defined
 import has_designator_prefix
 import has_part_picked
 import is_atomic_part
@@ -10,12 +9,11 @@ component Samsung_Electro_Mechanics_CL05B104KO5NNNC_package:
 
     # This trait marks this file as auto-generated
     # If you want to manually change it, remove the trait
-    trait is_auto_generated<system="ato_part", source="easyeda:C1525", date="2025-07-17T01:17:42.322423+00:00", checksum="0f6d15c88ded3c24787fac715258d831da891ed8f74d7e009b04b385324f5c27">
+    trait is_auto_generated<system="ato_part", source="easyeda:C1525", date="2025-08-21T00:08:25.065022+00:00", checksum="c0aa6ec45c141875ab655bf42c78e6fd30aa5fe5a0db2109d0dec3d83e6f7720">
 
     trait is_atomic_part<manufacturer="Samsung Electro-Mechanics", partnumber="CL05B104KO5NNNC", footprint="C0402.kicad_mod", symbol="CL05B104KO5NNNC.kicad_sym", model="C0402_L1.0-W0.5-H0.5.step">
     trait has_part_picked::by_supplier<supplier_id="lcsc", supplier_partno="C1525", manufacturer="Samsung Electro-Mechanics", partno="CL05B104KO5NNNC">
     trait has_designator_prefix<prefix="C">
-    trait has_datasheet_defined<datasheet="https://lcsc.com/datasheet/lcsc_datasheet_2304140030_Samsung-Electro-Mechanics-CL05B104KO5NNNC_C1525.pdf">
 
     # pins
     pin 2

--- a/packages/maxim-ds3502/parts/UNI_ROYAL_0402WGF4701TCE/R0402.kicad_mod
+++ b/packages/maxim-ds3502/parts/UNI_ROYAL_0402WGF4701TCE/R0402.kicad_mod
@@ -9,7 +9,7 @@
         (at 0 -4 0)
         (layer "F.SilkS")
         (hide no)
-        (uuid "ad284745-9833-42b3-8cc0-c68af5d9bcdf")
+        (uuid "c93e4c64-f84f-4e03-9a45-25a8f9965aa5")
         (effects
             (font
                 (size 1 1)
@@ -21,7 +21,7 @@
         (at 0 4 0)
         (layer "F.Fab")
         (hide no)
-        (uuid "d974e539-e7dd-4765-a570-7bbdb0e66bb5")
+        (uuid "5c6dc7bf-ced8-4d2e-8d14-1e3dde8315fa")
         (effects
             (font
                 (size 1 1)
@@ -33,7 +33,7 @@
         (at 0 0 0)
         (layer "User.9")
         (hide no)
-        (uuid "a2376b8b-547e-48b3-a361-a2658db62fdf")
+        (uuid "f06d41c2-23e8-498c-bf32-1101afc66fc9")
         (effects
             (font
                 (size 0.125 0.125)
@@ -51,7 +51,7 @@
             (type solid)
         )
         (layer "F.SilkS")
-        (uuid "5befe651-52a8-4c8b-9bfc-b0ab1edff76a")
+        (uuid "be005586-56f1-4209-92be-84195bf4394f")
     )
     (fp_line
         (start -0.94 0.5)
@@ -61,7 +61,7 @@
             (type solid)
         )
         (layer "F.SilkS")
-        (uuid "7abb75bd-2be3-437d-b292-38d11cb8398b")
+        (uuid "82f9b388-d606-4124-a8d4-5603c7c3f6c7")
     )
     (fp_line
         (start -0.94 -0.5)
@@ -71,7 +71,7 @@
             (type solid)
         )
         (layer "F.SilkS")
-        (uuid "1b9d747c-9c47-492f-a404-8a52f180379d")
+        (uuid "3575d6e5-ed5a-43a9-9bc6-9385da1e64f5")
     )
     (fp_line
         (start 0.23 0.5)
@@ -81,7 +81,7 @@
             (type solid)
         )
         (layer "F.SilkS")
-        (uuid "d825b4d7-de00-4ecf-9ff9-751b9aaa6aa9")
+        (uuid "c87d7556-597e-4f5e-964a-24d1efa25d69")
     )
     (fp_line
         (start 0.94 0.5)
@@ -91,7 +91,7 @@
             (type solid)
         )
         (layer "F.SilkS")
-        (uuid "c4ebbb1f-1a69-48ac-a86c-44d30310c8a7")
+        (uuid "345b711c-48b6-4f80-8822-8cfbd1c77b61")
     )
     (fp_line
         (start 0.94 -0.5)
@@ -101,7 +101,7 @@
             (type solid)
         )
         (layer "F.SilkS")
-        (uuid "d4cc2a9a-d2f6-4017-ac78-efaee4f9be54")
+        (uuid "50be0952-01be-44af-80f1-d4bbbf52dd80")
     )
     (fp_circle
         (center -0.5 0.25)
@@ -112,12 +112,12 @@
         )
         (fill no)
         (layer "F.Fab")
-        (uuid "3515a81f-9a9e-4b67-b6c4-0b80b0565bfb")
+        (uuid "9bdc7b50-73ab-44fb-9cee-547ffd8f532c")
     )
     (fp_text user "%R"
         (at 0 0 0)
         (layer "F.Fab")
-        (uuid "76f67181-80f0-466f-aa38-806898fc7679")
+        (uuid "0cdd0574-28dd-44fb-bc4e-b660e9e44d74")
         (effects
             (font
                 (size 1 1)
@@ -129,7 +129,7 @@
     (fp_text user "${REFERENCE}"
         (at 0 -4 0)
         (layer "F.SilkS")
-        (uuid "ad284745-9833-42b3-8cc0-c68af5d9bcdf")
+        (uuid "c93e4c64-f84f-4e03-9a45-25a8f9965aa5")
         (effects
             (font
                 (size 1 1)
@@ -142,13 +142,13 @@
         (at 0.43 0 0)
         (size 0.57 0.54)
         (layers "F.Cu" "F.Paste" "F.Mask")
-        (uuid "199e29a8-7c4b-47c7-8168-5f4cd81c33a8")
+        (uuid "fdf46de2-1ee2-4a0a-be6b-919a81618593")
     )
     (pad "1" smd rect
         (at -0.43 0 0)
         (size 0.57 0.54)
         (layers "F.Cu" "F.Paste" "F.Mask")
-        (uuid "9100c6c8-154a-4949-9b6a-230cdc0a9d8d")
+        (uuid "b5674ebe-8491-4a36-b544-83fba3091727")
     )
     (model "${KIPRJMOD}/../../parts/UNI_ROYAL_0402WGF4701TCE/R0402_L1.0-W0.5-H0.4.step"
         (offset

--- a/packages/maxim-ds3502/parts/UNI_ROYAL_0402WGF4701TCE/UNI_ROYAL_0402WGF4701TCE.ato
+++ b/packages/maxim-ds3502/parts/UNI_ROYAL_0402WGF4701TCE/UNI_ROYAL_0402WGF4701TCE.ato
@@ -1,5 +1,4 @@
 #pragma experiment("TRAITS")
-import has_datasheet_defined
 import has_designator_prefix
 import has_part_picked
 import is_atomic_part
@@ -10,12 +9,11 @@ component UNI_ROYAL_0402WGF4701TCE_package:
 
     # This trait marks this file as auto-generated
     # If you want to manually change it, remove the trait
-    trait is_auto_generated<system="ato_part", source="easyeda:C25900", date="2025-07-17T00:06:37.178340+00:00", checksum="1bb8f55969737a4217620592a7f0670b6d48978b8a5ab09cf787e6f89a290fb5">
+    trait is_auto_generated<system="ato_part", source="easyeda:C25900", date="2025-08-21T00:08:25.105432+00:00", checksum="e4a551c4bd6d3391eff7a8eee786e01c732c0aa34d8144f2ee985b7f8c044bd9">
 
     trait is_atomic_part<manufacturer="UNI-ROYAL", partnumber="0402WGF4701TCE", footprint="R0402.kicad_mod", symbol="0402WGF4701TCE.kicad_sym", model="R0402_L1.0-W0.5-H0.4.step">
     trait has_part_picked::by_supplier<supplier_id="lcsc", supplier_partno="C25900", manufacturer="UNI-ROYAL", partno="0402WGF4701TCE">
     trait has_designator_prefix<prefix="R">
-    trait has_datasheet_defined<datasheet="https://lcsc.com/datasheet/lcsc_datasheet_2411221126_UNI-ROYAL-0402WGF4701TCE_C25900.pdf">
 
     # pins
     pin 2

--- a/packages/maxim-ds3502/usage.ato
+++ b/packages/maxim-ds3502/usage.ato
@@ -1,43 +1,27 @@
 import ElectricPower
 import I2C
-import Electrical
 
 from "atopile/maxim-ds3502/maxim-ds3502.ato" import Maxim_DS3502
-
-# Example MCU providing I²C bus and reading the wiper voltage with an ADC pin
-module MCU:
-    power = new ElectricPower
-    i2c = new I2C
-    adc_in = new Electrical
 
 module Usage:
     """
     Minimal wiring for the Maxim DS3502 (10 kΩ) used as a programmable voltage divider.
 
     1. The potentiometer top end (`RH`) is tied to 3V3, bottom end (`RL`) to GND.
-    2. The wiper (`RW`) is routed to an MCU ADC input so firmware can read the
+    2. The wiper (`RW`) can be routed to an MCU ADC input so firmware can read the
        divided voltage and the DS3502 can trim it over I²C.
     3. Address pins `A1:A0` are left low which selects I²C address 0x28.
     """
 
-    # MCU with I²C and ADC capabilities
-    mcu = new MCU
-
-    # Shared 3 V3 rail
-    power_3v3 = new ElectricPower
-    power_3v3.voltage = 3.3V +/- 5%
-
-    # I²C bus (Fast-mode, 400 kHz)
-    i2c_bus = new I2C
-    i2c_bus.address = 0x28  # A1=A0=0 on DS3502
-
-    # DS3502 instance
+    # DS3502 digital potentiometer
     pot = new Maxim_DS3502
 
-    # Power distribution
-    power_3v3 ~ mcu.power
-    power_3v3 ~ pot.power
+    # Power supply (3.3V typical)
+    power = new ElectricPower
+    assert power.voltage within 3.3V +/- 5%
+    power ~ pot.power
 
-    # Connect I²C
-    i2c_bus ~ mcu.i2c
-    i2c_bus ~ pot.i2c
+    # I²C bus (would connect to your MCU)
+    i2c = new I2C
+    i2c.address = 0x28  # A1=A0=0 on DS3502
+    i2c ~ pot.i2c


### PR DESCRIPTION
## Summary
- Update maxim-ds3502 package to be compatible with atopile 0.11.6
- Simplify usage example to avoid picker warnings
- Package builds and verifies successfully

## Changes
- Update requires-atopile from ^0.10.8 to ^0.11.6
- Bump package version to 0.1.1
- Simplify usage.ato to remove MCU module pattern
- Update README.md to match simplified usage example
- Rebuild layouts with atopile 0.11.6

## Test plan
- [x] Run `ato build` - builds successfully
- [x] Run `ato build --frozen` - builds successfully with no warnings
- [x] Run `ato package verify` - verification passes

🤖 Generated with [Claude Code](https://claude.ai/code)