### PR TITLE
Update CI workflow for 0.14.x compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,29 +58,46 @@ jobs:
       # Build against a feature branch of atopile for 0.14.x package updates
       # Uses pre-built Docker image from the branch (built by atopile CI)
       # Docker tags replace '/' with '-', so feature/fabll_part2 -> feature-fabll_part2
-      - uses: atopile/setup-atopile@v1.7
+      - uses: atopile/setup-atopile@v1.8
         with:
           docker-tag: feature-fabll_part2
 
       - run: ato sync
         working-directory: ${{ matrix.package }}
 
-      # Note: --frozen removed since building against a branch may introduce changes
-      - run: ato build ${{ matrix.package }} --target all
+      - run: ato build ${{ matrix.package }} -t all
         env:
           GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
-      #TODO: put back -s
-      - run: ato package verify
+
+      - run: ato package verify -s
         working-directory: ${{ matrix.package }}
 
-      - uses: atopile/publish-package@v1
-        name: Publish package
+      - name: Publish dry run
+        if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+        working-directory: ${{ matrix.package }}
+        env:
+          ATO_CLI_PACKAGE_SKIP_DUPLICATE_VERSIONS: "true"
+          NONINTERACTIVE: "1"
+        run: ato package publish --dry-run
+
+      - name: Publish package
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        with:
-          package-entrypoint: ${{ matrix.package }}
-          skip-duplicate-versions: true
-          package-version: "" # Use the embedded version key
-          ato-config: ${{ matrix.package }}/ato.yaml
+        working-directory: ${{ matrix.package }}
+        env:
+          ATO_CLI_PACKAGE_SKIP_DUPLICATE_VERSIONS: "true"
+          NONINTERACTIVE: "1"
+        run: ato package publish
+
+      - name: Print errors and warnings on failure
+        if: failure()
+        run: |
+          pkg="${{ matrix.package }}"
+          echo "::group::Error Logs"
+          find "$pkg/build/logs" -name "*.error.log" -size +0 -exec echo "=== {} ===" \; -exec cat {} \; 2>/dev/null || true
+          echo "::endgroup::"
+          echo "::group::Warning Logs"
+          find "$pkg/build/logs" -name "*.warning.log" -size +0 -exec echo "=== {} ===" \; -exec cat {} \; 2>/dev/null || true
+          echo "::endgroup::"
 
       - name: Archive build logs
         id: archive_logs


### PR DESCRIPTION
- Upgrade setup-atopile to v1.8
- Use -t all flag for build
- Add -s flag to package verify
- Replace publish-package action with manual ato package publish
- Add dry-run publish for non-main branches
- Add error/warning log printing on failure
- Add build log archiving