### PR TITLE
bosch-bme688: uprev to v0.2.1, frozen update

### DIFF
--- a/packages/bosch-bme688/ato.yaml
+++ b/packages/bosch-bme688/ato.yaml
@@ -17,7 +17,7 @@ package:
   identifier: atopile/bosch-bme688
   repository: https://github.com/atopile/packages
   homepage: https://github.com/atopile/packages/blob/main/packages/bosch-bme688/README.md
-  version: "0.2.1"
+  version: 0.2.1
   authors:
   - name: atopile
     email: hi@atopile.io

--- a/packages/bosch-bme688/layouts/default/default.kicad_pcb
+++ b/packages/bosch-bme688/layouts/default/default.kicad_pcb
@@ -103,7 +103,7 @@
 				)
 			)
 		)
-		(property "Value" "4700±1.0%Ω"
+		(property "Value" "4700Ω"
 			(at 0 4 180)
 			(layer "F.Fab")
 			(hide yes)
@@ -235,7 +235,7 @@
 				)
 			)
 		)
-		(property "resistance" "4700±1.0%Ω"
+		(property "resistance" "4700±5.0%Ω"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
@@ -247,7 +247,7 @@
 				)
 			)
 		)
-		(property "max_power" "0.062W"
+		(property "max_power" "ℝ+W"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
@@ -259,7 +259,7 @@
 				)
 			)
 		)
-		(property "max_voltage" "50V"
+		(property "max_voltage" "ℝ+V"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
@@ -433,7 +433,7 @@
 				)
 			)
 		)
-		(property "Value" "1±10.0%F"
+		(property "Value" "1F"
 			(at 0 4 180)
 			(layer "F.Fab")
 			(hide yes)
@@ -565,7 +565,7 @@
 				)
 			)
 		)
-		(property "capacitance" "1±10.0%F"
+		(property "capacitance" "1±20.0%F"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
@@ -577,7 +577,7 @@
 				)
 			)
 		)
-		(property "max_voltage" "16V"
+		(property "max_voltage" "ℝ+V"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
@@ -811,7 +811,7 @@
 				)
 			)
 		)
-		(property "Value" "{8.999..1.1}F"
+		(property "Value" "1e-08F"
 			(at 0 4 180)
 			(layer "F.Fab")
 			(hide yes)
@@ -943,7 +943,7 @@
 				)
 			)
 		)
-		(property "capacitance" "{8.999..1.1}F"
+		(property "capacitance" "1e-08±20.0%F"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
@@ -955,7 +955,7 @@
 				)
 			)
 		)
-		(property "max_voltage" "50V"
+		(property "max_voltage" "ℝ+V"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
@@ -1519,7 +1519,7 @@
 				)
 			)
 		)
-		(property "Value" "1±10.0%F"
+		(property "Value" "1F"
 			(at 0 4 180)
 			(layer "F.Fab")
 			(hide yes)
@@ -1651,7 +1651,7 @@
 				)
 			)
 		)
-		(property "capacitance" "1±10.0%F"
+		(property "capacitance" "1±20.0%F"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
@@ -1663,7 +1663,7 @@
 				)
 			)
 		)
-		(property "max_voltage" "16V"
+		(property "max_voltage" "ℝ+V"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
@@ -1897,7 +1897,7 @@
 				)
 			)
 		)
-		(property "Value" "4700±1.0%Ω"
+		(property "Value" "4700Ω"
 			(at 0 4 180)
 			(layer "F.Fab")
 			(hide yes)
@@ -2029,7 +2029,7 @@
 				)
 			)
 		)
-		(property "resistance" "4700±1.0%Ω"
+		(property "resistance" "4700±5.0%Ω"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
@@ -2041,7 +2041,7 @@
 				)
 			)
 		)
-		(property "max_power" "0.062W"
+		(property "max_power" "ℝ+W"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
@@ -2053,7 +2053,7 @@
 				)
 			)
 		)
-		(property "max_voltage" "50V"
+		(property "max_voltage" "ℝ+V"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
@@ -2227,7 +2227,7 @@
 				)
 			)
 		)
-		(property "Value" "{8.999..1.1}F"
+		(property "Value" "1e-08F"
 			(at 0 4 180)
 			(layer "F.Fab")
 			(hide yes)
@@ -2359,7 +2359,7 @@
 				)
 			)
 		)
-		(property "capacitance" "{8.999..1.1}F"
+		(property "capacitance" "1e-08±20.0%F"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
@@ -2371,7 +2371,7 @@
 				)
 			)
 		)
-		(property "max_voltage" "50V"
+		(property "max_voltage" "ℝ+V"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)

--- a/packages/bosch-bme688/layouts/usage/usage.kicad_pcb
+++ b/packages/bosch-bme688/layouts/usage/usage.kicad_pcb
@@ -108,7 +108,7 @@
 				)
 			)
 		)
-		(property "Value" "{8.999..1.1}F"
+		(property "Value" "1e-08F"
 			(at 0 4 180)
 			(layer "F.Fab")
 			(hide no)
@@ -252,13 +252,13 @@
 				)
 			)
 		)
-		(property "capacitance" "{8.999..1.1}F"
+		(property "capacitance" "1e-08±20.0%F"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
 			(uuid "8788cc8e-be7c-47e0-8eaa-8a394642524b")
 		)
-		(property "max_voltage" "50V"
+		(property "max_voltage" "ℝ+V"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
@@ -468,7 +468,7 @@
 				)
 			)
 		)
-		(property "Value" "4700±1.0%Ω"
+		(property "Value" "4700Ω"
 			(at 0 4 180)
 			(layer "F.Fab")
 			(hide no)
@@ -612,19 +612,19 @@
 				)
 			)
 		)
-		(property "resistance" "4700±1.0%Ω"
+		(property "resistance" "4700±5.0%Ω"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
 			(uuid "d4674a75-f49a-476a-92b7-49944642524b")
 		)
-		(property "max_power" "0.062W"
+		(property "max_power" "ℝ+W"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
 			(uuid "c752133b-4f58-481a-bb60-9e524642524b")
 		)
-		(property "max_voltage" "50V"
+		(property "max_voltage" "ℝ+V"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
@@ -1118,7 +1118,7 @@
 				)
 			)
 		)
-		(property "Value" "1±10.0%F"
+		(property "Value" "1F"
 			(at 0 4 180)
 			(layer "F.Fab")
 			(hide no)
@@ -1262,13 +1262,13 @@
 				)
 			)
 		)
-		(property "capacitance" "1±10.0%F"
+		(property "capacitance" "1±20.0%F"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
 			(uuid "29386b3b-8c54-4a6e-9509-27674642524b")
 		)
-		(property "max_voltage" "16V"
+		(property "max_voltage" "ℝ+V"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
@@ -1478,7 +1478,7 @@
 				)
 			)
 		)
-		(property "Value" "4700±1.0%Ω"
+		(property "Value" "4700Ω"
 			(at 0 4 180)
 			(layer "F.Fab")
 			(hide no)
@@ -1622,19 +1622,19 @@
 				)
 			)
 		)
-		(property "resistance" "4700±1.0%Ω"
+		(property "resistance" "4700±5.0%Ω"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
 			(uuid "c27f6214-2623-400f-b3bb-a9ff4642524b")
 		)
-		(property "max_power" "0.062W"
+		(property "max_power" "ℝ+W"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
 			(uuid "986d87de-f375-4a70-85aa-dcff4642524b")
 		)
-		(property "max_voltage" "50V"
+		(property "max_voltage" "ℝ+V"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
@@ -1790,7 +1790,7 @@
 				)
 			)
 		)
-		(property "Value" "1±10.0%F"
+		(property "Value" "1F"
 			(at 0 4 180)
 			(layer "F.Fab")
 			(hide no)
@@ -1934,13 +1934,13 @@
 				)
 			)
 		)
-		(property "capacitance" "1±10.0%F"
+		(property "capacitance" "1±20.0%F"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
 			(uuid "31d89a2c-c9e1-4900-9365-f33c4642524b")
 		)
-		(property "max_voltage" "16V"
+		(property "max_voltage" "ℝ+V"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
@@ -2150,7 +2150,7 @@
 				)
 			)
 		)
-		(property "Value" "{8.999..1.1}F"
+		(property "Value" "1e-08F"
 			(at 0 4 180)
 			(layer "F.Fab")
 			(hide no)
@@ -2294,13 +2294,13 @@
 				)
 			)
 		)
-		(property "capacitance" "{8.999..1.1}F"
+		(property "capacitance" "1e-08±20.0%F"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)
 			(uuid "be68d73e-7041-4402-90bd-4ac34642524b")
 		)
-		(property "max_voltage" "50V"
+		(property "max_voltage" "ℝ+V"
 			(at 0 0 0)
 			(layer "User.9")
 			(hide yes)


### PR DESCRIPTION
Version bump: 0.2.0 → 0.2.1

Reviewer: Nicholas Krstevski